### PR TITLE
docs(infra): add MCP testing workflow etapa 1 y 2 [E0-INF-12]

### DIFF
--- a/doc/infra/ngrok-setup.md
+++ b/doc/infra/ngrok-setup.md
@@ -1,0 +1,96 @@
+# ngrok — Setup y tunnel MCP para testing con Claude
+
+Procedimiento para exponer el WSO2 API Gateway local a internet usando ngrok,
+permitiendo que Claude.ai invoque el servidor MCP de Trazalog en desarrollo.
+
+---
+
+## 1. Instalación (Ubuntu 24)
+
+Se usa el repositorio oficial de ngrok vía apt:
+
+```bash
+curl -sSL https://ngrok-agent.s3.amazonaws.com/ngrok.asc \
+  | sudo tee /etc/apt/trusted.gpg.d/ngrok.asc >/dev/null
+
+echo "deb https://ngrok-agent.s3.amazonaws.com buster main" \
+  | sudo tee /etc/apt/sources.list.d/ngrok.list
+
+sudo apt update && sudo apt install ngrok
+```
+
+Versión instalada: **3.39.1**
+
+---
+
+## 2. Autenticación
+
+Registrarse en [ngrok.com](https://ngrok.com) y obtener el authtoken desde el dashboard.
+Configurarlo una sola vez:
+
+```bash
+ngrok config add-authtoken <TOKEN>
+```
+
+El token queda guardado en `~/.config/ngrok/ngrok.yml`.
+
+---
+
+## 3. Lanzar el tunnel al WSO2 Gateway (puerto 8243)
+
+Con WSO2 API Manager corriendo localmente:
+
+```bash
+ngrok http 8243
+```
+
+Salida esperada (ejemplo del smoke test ejecutado 2026-05-16):
+
+```
+Session Status    online
+Region            South America (sa)
+Web Interface     http://127.0.0.1:4040
+Forwarding        https://129e-200-114-96-54.ngrok-free.app -> https://localhost:8243
+```
+
+La URL pública (`https://<id>.ngrok-free.app`) es la que se usa como base para el
+conector MCP en Claude.ai.
+
+La región South America (sa) se elige automáticamente por geolocalización — no
+requiere configuración adicional.
+
+---
+
+## 4. Limitaciones del plan free
+
+| Limitación | Detalle |
+|---|---|
+| URL efímera | La URL pública cambia cada vez que se reinicia ngrok |
+| Sin dominios fijos | El plan pago permite dominios estáticos |
+| Conexiones simultáneas | 1 tunnel activo por cuenta en el plan free |
+
+**Workaround para la URL cambiante**: cada vez que se reinicie ngrok, copiar la nueva
+URL y actualizar el custom connector en Claude.ai:
+
+> Settings → Connectors → (seleccionar el conector existente) → editar URL
+
+El **dashboard local** en `http://127.0.0.1:4040` muestra todos los requests que
+pasan por el tunnel en tiempo real — indispensable para debug de llamadas MCP.
+
+---
+
+## 5. Agregar el custom connector en Claude.ai (E0-INF-12)
+
+Una vez que ngrok está activo y WSO2 está corriendo:
+
+1. Copiar la URL del tunnel desde la salida de ngrok (ej: `https://129e-200-114-96-54.ngrok-free.app`)
+2. Abrir Claude.ai → **Settings** → **Connectors** → **Add custom connector**
+3. Completar la URL del endpoint MCP:
+   ```
+   https://<url-ngrok>/mcp
+   ```
+4. Guardar y verificar que Claude detecta las herramientas expuestas por el servidor MCP
+
+> **Nota**: el path `/mcp` corresponde al endpoint configurado en WSO2 APIM para el
+> servidor MCP de Trazalog. Verificar en el API Publisher que el contexto de la API
+> coincide antes de registrar el conector.

--- a/doc/infra/testing-workflow.md
+++ b/doc/infra/testing-workflow.md
@@ -1,0 +1,78 @@
+# Testing Workflow — MCP Trazalog v3
+
+Flujo de testing en dos etapas para tools MCP expuestas via WSO2 APIM 4.6.0.
+
+---
+
+## Las dos etapas
+
+### Etapa 1 — MCP Inspector (testing técnico local)
+
+**Cuándo usarlo:** validar schemas JSON-RPC, contratos de tools y respuestas del servidor
+*antes* de involucrar a Claude. No requiere internet ni cuenta Claude Pro.
+
+```bash
+npx @modelcontextprotocol/inspector
+```
+
+UI disponible en: http://localhost:6274
+
+**Qué valida:**
+- Estructura de `tools/list`
+- Parámetros y tipos de datos
+- Error handling
+
+**Cuándo está completo:** todas las tools responden con schema correcto en Inspector.
+
+---
+
+### Etapa 2 — Claude.ai con ngrok (testing semántico end-to-end)
+
+**Cuándo usarlo:** después de pasar Etapa 1. Valida que Claude entiende las descripciones
+de las tools y las invoca correctamente en contexto real.
+
+**Requisitos:** Claude Pro activo + ngrok corriendo + WSO2 APIM levantado.
+
+**Tunnel ngrok (crítico — WSO2 usa HTTPS en puerto 8243):**
+
+```bash
+# CORRECTO
+ngrok http https://localhost:8243
+
+# INCORRECTO — rompe el handshake SSL
+ngrok http 8243
+```
+
+**Configurar connector en Claude.ai:**
+Settings → Connectors → Add custom connector → URL: `https://<id>.ngrok-free.app`
+
+> **Plan free:** la URL ngrok cambia en cada reinicio. Actualizar el connector en Claude.ai
+> cada vez que se reinicie ngrok.
+
+**Qué valida:**
+- Semántica de las tool descriptions
+- Comportamiento de Claude al invocar tools
+- Respuestas en lenguaje natural
+
+---
+
+## Cuándo usar cada etapa
+
+| Situación | Etapa |
+|---|---|
+| Crear una tool nueva | Etapa 1 primero, luego Etapa 2 |
+| Cambiar parámetros de una tool existente | Etapa 1 |
+| Cambiar la descripción semántica de una tool | Etapa 2 |
+| Debugging de error JSON-RPC | Etapa 1 |
+| Validar que Claude invoca la tool correcta ante una pregunta | Etapa 2 |
+| Antes de hacer PR de una tool nueva | Ambas etapas |
+
+---
+
+## Checklist antes de cerrar un issue de tool MCP
+
+- [ ] Tool pasa Etapa 1: MCP Inspector devuelve schema correcto
+- [ ] Tool tiene annotation correcta (`readOnlyHint` o `destructiveHint`) — ver [`doc/mcp/tool-annotations-standard.md`](../mcp/tool-annotations-standard.md)
+- [ ] Tool pasa Etapa 2: Claude la invoca correctamente con una pregunta en lenguaje natural
+- [ ] Tool result < 25.000 tokens
+- [ ] Timeout < 5 minutos

--- a/doc/infra/wso2-install.md
+++ b/doc/infra/wso2-install.md
@@ -1,0 +1,200 @@
+# WSO2 API Manager 4.6.0 — Instalación en DEV
+
+Procedimiento real ejecutado en la workstation del PM (Ubuntu 24).
+Referencia para reproducir en entornos TEST y PROD (ver notas al final).
+
+---
+
+## Entorno
+
+| Item | Valor |
+|---|---|
+| OS | Ubuntu 24 |
+| Path de instalación | `/mnt/win/dev/wso2am-4.6.0/` |
+| Java | Temurin OpenJDK 21 |
+| JAVA_HOME | configurado en `/etc/profile.d/jdk21.sh` |
+| Modo | All-in-one (single node, sin profileSetup) |
+| Base de datos | H2 embebida (solo DEV — ver sección de notas) |
+
+> **Por qué no `/opt/`**: espacio en disco insuficiente en la partición del sistema.
+> La partición montada en `/mnt/win/dev/` tiene el espacio disponible.
+
+---
+
+## 1. Prerequisito: Java 21 Temurin
+
+WSO2 APIM 4.6.0 requiere JDK 21. Verificar antes de continuar:
+
+```bash
+java -version
+# openjdk version "21.x.x" ...
+
+echo $JAVA_HOME
+# /usr/lib/jvm/temurin-21-amd64  (o equivalente)
+```
+
+Si `JAVA_HOME` no está seteado, crearlo en `/etc/profile.d/jdk21.sh`:
+
+```bash
+export JAVA_HOME=/usr/lib/jvm/temurin-21-amd64
+export PATH=$JAVA_HOME/bin:$PATH
+```
+
+Luego `source /etc/profile.d/jdk21.sh` o reiniciar la sesión.
+
+---
+
+## 2. Descarga e instalación
+
+```bash
+# Descargar el zip oficial desde wso2.com/api-platform/api-manager/
+# (requiere cuenta gratuita en wso2.com)
+
+# Descomprimir en el path de destino
+cd /mnt/win/dev/
+unzip wso2am-4.6.0.zip
+
+# El directorio resultante es /mnt/win/dev/wso2am-4.6.0/
+
+# Dar permisos de ejecución al script principal
+chmod +x /mnt/win/dev/wso2am-4.6.0/bin/api-manager.sh
+```
+
+---
+
+## 3. Configuración (deployment.toml)
+
+Path: `/mnt/win/dev/wso2am-4.6.0/repository/conf/deployment.toml`
+
+Cambios aplicados sobre el archivo default. Solo se listan las secciones modificadas;
+el resto queda con los valores default de WSO2:
+
+```toml
+[server]
+hostname = "localhost"
+mode = "single"
+
+[super_admin]
+username = "admin"
+password = "admin"
+create_admin_account = true
+
+[user_store]
+type = "database_unique_id"
+
+[database.apim_db]
+type = "h2"
+
+[database.shared_db]
+type = "h2"
+
+[[apim.gateway.environment]]
+name = "Default"
+# todos los endpoints apuntan a localhost (valores default de la instalación)
+
+[apim.analytics]
+enable = false
+```
+
+> La configuración completa está en el kickoff doc del proyecto.
+> H2 es la base embebida de WSO2 — válida solo en DEV, sin datos persistentes entre
+> reinstalaciones. Para TEST y PROD usar PostgreSQL (ver E0-INF-05).
+
+---
+
+## 4. Arranque
+
+```bash
+cd /mnt/win/dev/wso2am-4.6.0
+./bin/api-manager.sh start
+```
+
+Seguir los logs durante el primer arranque (~3-4 minutos):
+
+```bash
+tail -f repository/logs/wso2carbon.log
+```
+
+El servidor está listo cuando aparece en el log:
+
+```
+[INFO] WSO2 API Manager started in X seconds
+```
+
+Otros comandos útiles:
+
+```bash
+./bin/api-manager.sh stop
+./bin/api-manager.sh restart
+./bin/api-manager.sh status
+```
+
+---
+
+## 5. Smoke test ejecutado y validado
+
+### Consolas web
+
+| Endpoint | URL | Estado |
+|---|---|---|
+| Publisher | https://localhost:9443/publisher | OK |
+| Developer Portal | https://localhost:9443/devportal | OK |
+| Admin Console | https://localhost:9443/carbon | OK |
+
+Credenciales: `admin` / `admin`
+
+El browser muestra advertencia de certificado self-signed — aceptar la excepción
+para continuar (solo en DEV).
+
+### Gateway (puerto 8243)
+
+El Gateway usa HTTPS con certificado self-signed. Validar con curl, no con el browser:
+
+```bash
+curl -k https://localhost:8243
+# Respuesta: "Welcome to WSO2 API Manager" (o similar)
+```
+
+### API HelloWorld
+
+Se creó una API de prueba desde el Publisher, se publicó y se consumió exitosamente
+desde el Developer Portal — flujo completo validado.
+
+### Tunnel ngrok
+
+```bash
+ngrok http https://localhost:8243
+```
+
+URL pública generada y accesible desde internet — smoke test completo del flujo
+MCP end-to-end confirmado.
+
+---
+
+## 6. Notas para reproducir en TEST / PROD
+
+**Puerto 8243 es HTTPS — ngrok requiere esquema explícito:**
+
+```bash
+# CORRECTO
+ngrok http https://localhost:8243
+
+# INCORRECTO — rompe el handshake SSL
+ngrok http 8243
+```
+
+**Certificado self-signed en localhost:8243:**
+El browser bloquea la conexión directa al Gateway. Usar siempre `curl -k` para
+validar el Gateway en DEV. En TEST/PROD configurar un certificado válido.
+
+**Base de datos:**
+H2 es solo para DEV. Para TEST y PROD reemplazar las secciones `[database.*]` en
+`deployment.toml` con la configuración PostgreSQL correspondiente (ver E0-INF-05).
+
+**Permisos en filesystem NTFS (Windows/WSL):**
+Si los scripts `.sh` pierden el bit de ejecución después de descomprimir en una
+partición NTFS montada desde Windows:
+
+```bash
+find /mnt/win/dev/wso2am-4.6.0/bin -name "*.sh" -exec chmod +x {} \;
+```


### PR DESCRIPTION
## Summary

- Agrega `doc/infra/testing-workflow.md` con el flujo de testing MCP en dos etapas
- **Etapa 1:** MCP Inspector (validación técnica local — schemas, contratos, error handling)
- **Etapa 2:** Claude.ai + ngrok (validación semántica end-to-end)
- Incluye tabla de decisión por situación y checklist de DoD para issues de tools MCP

## Test plan

- [ ] Verificar que `doc/infra/testing-workflow.md` existe en la ruta correcta (`doc/`, no `docs/`)
- [ ] Verificar que el link a `tool-annotations-standard.md` es relativo y correcto
- [ ] Verificar que el comando ngrok incorrecto está claramente marcado como tal

🤖 Generated with [Claude Code](https://claude.com/claude-code)