### PR TITLE
feat(infra): sizing VM GCP + scripts instalación nativa WSO2 [E7-INFRA-01/02]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ tests/security/test-env.vars
 
 # Artefacto compilado del CAR de discovery — regenerable con build.sh
 _backend/api/ApimDiscoveryProject/build/
+
+# Secretos de despliegue GCP (ADR-011) — copiar de deploy/gcp/.env.example
+deploy/gcp/.env

--- a/deploy/gcp/.env.example
+++ b/deploy/gcp/.env.example
@@ -39,9 +39,12 @@ MI_HOME=/opt/wso2/wso2mi-4.5.0
 WSO2_SYSTEM_USER=wso2carbon
 
 # ── Heap sizes — ver doc/v3/deployment-gcp.md § Sizing ──────────────
-# Tier elegido: e2-standard-2 (2 vCPU / 8 GB). El grueso de RAM va al APIM
-# (ADR-011 punto 4); el MI queda cerca de su default liviano de fábrica.
-APIM_XMS=2g
-APIM_XMX=3g
+# Tier elegido: e2-medium (2 vCPU / 4 GB) — mínimo indispensable para el
+# piloto de 1-2 usuarios, no el catálogo oficial de WSO2 (pensado para
+# producción con carga concurrente real). MI queda en su default de
+# fábrica ya validado en DEV; el APIM recibe algo más de RAM (ADR-011 #4)
+# pero muy por debajo del mínimo "de catálogo" de 2 GB heap.
+APIM_XMS=512m
+APIM_XMX=1536m
 MI_XMS=256m
-MI_XMX=768m
+MI_XMX=1024m

--- a/deploy/gcp/.env.example
+++ b/deploy/gcp/.env.example
@@ -1,0 +1,47 @@
+# ══════════════════════════════════════════════════════════════════
+# deploy/gcp/.env.example
+# Copiar a deploy/gcp/.env (gitignored) y completar antes de correr
+# install-apim.sh / install-mi.sh / setup-reverse-proxy.sh.
+# Ver doc/v3/deployment-gcp.md para el detalle de cada valor.
+# ══════════════════════════════════════════════════════════════════
+
+# ── Dominio público (reverse proxy + TLS Let's Encrypt, ADR-011 #7) ──
+MCP_DOMAIN=mcp.cloudtrazalog.com
+LETSENCRYPT_EMAIL=
+
+# ── PostgreSQL externa — YA EXISTE en el proyecto GCP, no se crea acá ──
+# Esta conexión es para el registro/metadata INTERNO de APIM
+# ([database.apim_db] / [database.shared_db] de deployment.toml).
+# NO es la conexión de las DataServices de negocio del MI — esa migración
+# de MySQL/legacy a esta misma PostgreSQL es un trabajo aparte, ya en curso
+# (ver doc/identity/dataservices-remediation-phase-a.md). No asumir que
+# completar este .env migra las DataServices.
+PG_HOST=
+PG_PORT=5432
+PG_DB_APIM=wso2am_db
+PG_DB_SHARED=wso2shared_db
+PG_USER=
+PG_PASSWORD=
+
+# Ruta al .jar del driver JDBC de PostgreSQL (descargado manualmente desde
+# https://jdbc.postgresql.org/download/ — no se commitea al repo).
+PG_JDBC_JAR_PATH=/opt/wso2/drivers/postgresql-42.7.4.jar
+
+# ── Distributables WSO2 — descargados manualmente desde wso2.com ────
+# (requiere cuenta gratuita; ver doc/infra/wso2-install.md sección 2 para
+# el procedimiento ya validado en DEV). Los scripts NO los descargan solos.
+APIM_ZIP_PATH=/opt/wso2/dist/wso2am-4.6.0.zip
+MI_ZIP_PATH=/opt/wso2/dist/wso2mi-4.5.0.zip
+
+# ── Rutas de instalación nativa ──────────────────────────────────
+APIM_HOME=/opt/wso2/wso2am-4.6.0
+MI_HOME=/opt/wso2/wso2mi-4.5.0
+WSO2_SYSTEM_USER=wso2carbon
+
+# ── Heap sizes — ver doc/v3/deployment-gcp.md § Sizing ──────────────
+# Tier elegido: e2-standard-2 (2 vCPU / 8 GB). El grueso de RAM va al APIM
+# (ADR-011 punto 4); el MI queda cerca de su default liviano de fábrica.
+APIM_XMS=2g
+APIM_XMX=3g
+MI_XMS=256m
+MI_XMX=768m

--- a/deploy/gcp/README.md
+++ b/deploy/gcp/README.md
@@ -16,6 +16,11 @@ otro proveedor o topología, va en `deploy/<nuevo-proveedor>/`, no acá adentro.
 
 ## Orden de ejecución (en la VM GCP, no localmente)
 
+SO objetivo: **Rocky Linux 9** (IDR-001, ver `deployment-gcp.md` §1.1). Antes de
+correr los scripts, instalar JDK 21 Temurin (ver checklist §4 paso 6 de
+`deployment-gcp.md`) — `install-apim.sh`/`install-mi.sh` lo detectan solo y
+lo dejan seteado en el unit de systemd.
+
 ```bash
 cp .env.example .env
 # completar .env con los valores reales (PostgreSQL externa, dominio, etc.)

--- a/deploy/gcp/README.md
+++ b/deploy/gcp/README.md
@@ -1,0 +1,39 @@
+# deploy/gcp/
+
+Scripts de instalación **nativa** (sin Docker) del stack WSO2 en la VM de GCP
+del early adopter minero. Implementa [ADR-011](../../doc/adr/ADR-011-gcp-deployment.md).
+
+Documentación completa (sizing, justificación, checklist para Rodolfo en la
+consola de GCP): [`doc/v3/deployment-gcp.md`](../../doc/v3/deployment-gcp.md).
+
+## Convención de esta carpeta
+
+`deploy/<proveedor>/` para artefactos de despliegue ejecutables sobre
+infraestructura real (scripts, unidades systemd, config de reverse proxy).
+Se diferencia de `doc/infra/` (documentación de procedimientos) y de
+`scripts/dev/` (scripts de setup de DEV/testing). Si en el futuro se agrega
+otro proveedor o topología, va en `deploy/<nuevo-proveedor>/`, no acá adentro.
+
+## Orden de ejecución (en la VM GCP, no localmente)
+
+```bash
+cp .env.example .env
+# completar .env con los valores reales (PostgreSQL externa, dominio, etc.)
+
+sudo ./install-apim.sh
+sudo ./install-mi.sh
+sudo ./setup-reverse-proxy.sh
+
+sudo systemctl start wso2am
+sudo systemctl start wso2mi
+```
+
+## Qué NO hacen estos scripts
+
+- No descargan los `.zip` de WSO2 (requieren cuenta en wso2.com — descarga manual).
+- No configuran identidad/JWT/Key Manager (ADR-008/ADR-009) — es clase 🔴, deuda
+  aparte antes de dar de alta al primer cliente.
+- No migran las DataServices de negocio del MI de MySQL a PostgreSQL — trabajo
+  en curso aparte (`doc/identity/dataservices-remediation-phase-a.md`).
+- No crean la VM, la IP estática, el DNS, ni las reglas de firewall — eso lo
+  hace Rodolfo en su consola de GCP (checklist en `deployment-gcp.md`).

--- a/deploy/gcp/install-apim.sh
+++ b/deploy/gcp/install-apim.sh
@@ -132,10 +132,27 @@ else
   log "AVISO: no se encontraron flags -Xms/-Xmx en api-manager.sh — ajustar heap manualmente"
 fi
 
+# ── JAVA_HOME (JDK 21 requerido por WSO2 4.6.0 — ver doc/v3/deployment-gcp.md §4) ──
+# systemd no lee /etc/profile.d, así que hace falta resolver JAVA_HOME acá y
+# escribirlo explícitamente en el unit (a diferencia de DEV, que lo setea en
+# el perfil de shell — ver doc/infra/wso2-install.md).
+if [ -n "${JAVA_HOME:-}" ] && [ -x "$JAVA_HOME/bin/java" ]; then
+  JAVA_HOME_RESOLVED="$JAVA_HOME"
+else
+  JAVA_BIN="$(command -v java || true)"
+  [ -n "$JAVA_BIN" ] || die "No se encontró Java. Instalar JDK 21 Temurin primero (doc/v3/deployment-gcp.md §4)."
+  JAVA_BIN="$(readlink -f "$JAVA_BIN")"
+  JAVA_HOME_RESOLVED="$(dirname "$(dirname "$JAVA_BIN")")"
+fi
+"$JAVA_HOME_RESOLVED/bin/java" -version 2>&1 | grep -q '"21\.' \
+  || die "Se requiere JDK 21 (WSO2 4.6.0) — detectado: $("$JAVA_HOME_RESOLVED/bin/java" -version 2>&1 | head -1)"
+log "JAVA_HOME detectado: $JAVA_HOME_RESOLVED (JDK 21 verificado)"
+
 # ── Permisos y systemd ─────────────────────────────────────────────
 chown -R "$WSO2_USER:$WSO2_USER" "$APIM_HOME"
 
 sed -e "s#{{APIM_HOME}}#$APIM_HOME#g" -e "s#{{WSO2_USER}}#$WSO2_USER#g" \
+    -e "s#{{JAVA_HOME}}#$JAVA_HOME_RESOLVED#g" \
   "$SCRIPT_DIR/systemd/wso2am.service" > /etc/systemd/system/wso2am.service
 systemctl daemon-reload
 systemctl enable wso2am.service

--- a/deploy/gcp/install-apim.sh
+++ b/deploy/gcp/install-apim.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+# install-apim.sh
+# Instalación NATIVA (sin Docker) de WSO2 API Manager 4.6.0 en la VM de GCP.
+# Aplica ADR-011: descomprime el .zip, conecta el registro/metadata interno
+# de APIM a la PostgreSQL externa ya existente, ajusta el heap prioritario
+# del APIM, y deja el servicio corriendo bajo systemd.
+#
+# Fuera de alcance de este script (ver doc/v3/deployment-gcp.md):
+#   - Configuración de identidad ([apim.jwt], Key Manager federado Dnato,
+#     ADR-008/ADR-009). Es clase 🔴 (identidad/seguridad) — no se toca acá.
+#   - Migración de las DataServices de negocio del MI a PostgreSQL.
+#
+# PRE:
+#   - deploy/gcp/.env presente (copiar de .env.example y completar)
+#   - .zip de WSO2 APIM descargado manualmente desde wso2.com (requiere
+#     cuenta) en la ruta APIM_ZIP_PATH — ver doc/infra/wso2-install.md §2
+#   - Driver JDBC de PostgreSQL descargado en PG_JDBC_JAR_PATH
+#     (https://jdbc.postgresql.org/download/)
+# USO: sudo ./install-apim.sh   (en la VM GCP)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="$SCRIPT_DIR/.env"
+
+log() { echo "[install-apim] $*"; }
+die() { echo "[ERROR] $*" >&2; exit 1; }
+
+[ -f "$ENV_FILE" ] || die "No se encontró $ENV_FILE — copiar .env.example y completar"
+set -a
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+set +a
+
+for var in APIM_ZIP_PATH APIM_HOME APIM_XMS APIM_XMX PG_HOST PG_PORT PG_DB_APIM PG_DB_SHARED PG_USER PG_PASSWORD MCP_DOMAIN; do
+  [ -n "${!var:-}" ] || die "Falta $var en .env"
+done
+
+[ -f "$APIM_ZIP_PATH" ] || die "No se encontró el zip de APIM en $APIM_ZIP_PATH"
+
+WSO2_USER="${WSO2_SYSTEM_USER:-wso2carbon}"
+INSTALL_PARENT="$(dirname "$APIM_HOME")"
+
+# ── Usuario de sistema dedicado (sin login) ──────────────────────
+if ! id "$WSO2_USER" >/dev/null 2>&1; then
+  log "Creando usuario de sistema $WSO2_USER..."
+  useradd --system --no-create-home --shell /usr/sbin/nologin "$WSO2_USER"
+fi
+
+# ── Descompresión ─────────────────────────────────────────────────
+if [ -d "$APIM_HOME" ]; then
+  log "AVISO: $APIM_HOME ya existe — se omite la descompresión (instalación existente)"
+else
+  log "Descomprimiendo $APIM_ZIP_PATH en $INSTALL_PARENT..."
+  mkdir -p "$INSTALL_PARENT"
+  UNZIP_TMP="$(mktemp -d)"
+  unzip -q "$APIM_ZIP_PATH" -d "$UNZIP_TMP"
+  UNZIPPED_DIR="$(find "$UNZIP_TMP" -mindepth 1 -maxdepth 1 -type d | head -1)"
+  [ -n "$UNZIPPED_DIR" ] || die "El zip no contiene el directorio esperado"
+  mv "$UNZIPPED_DIR" "$APIM_HOME"
+  rmdir "$UNZIP_TMP" 2>/dev/null || true
+fi
+find "$APIM_HOME/bin" -iname "*.sh" -exec chmod +x {} \;
+
+# ── Driver JDBC PostgreSQL ────────────────────────────────────────
+if [ -n "${PG_JDBC_JAR_PATH:-}" ] && [ -f "$PG_JDBC_JAR_PATH" ]; then
+  cp "$PG_JDBC_JAR_PATH" "$APIM_HOME/repository/components/lib/"
+  log "Driver JDBC PostgreSQL copiado a repository/components/lib/"
+else
+  log "AVISO: PG_JDBC_JAR_PATH no configurado o inexistente."
+  log "  Copiar manualmente el .jar del driver a $APIM_HOME/repository/components/lib/ antes de arrancar."
+fi
+
+# ── deployment.toml: hostname + database.apim_db + database.shared_db ──
+TOML="$APIM_HOME/repository/conf/deployment.toml"
+BACKUP="$TOML.orig-$(date +%Y%m%d%H%M%S)"
+cp "$TOML" "$BACKUP"
+log "Backup del deployment.toml original: $BACKUP"
+
+MCP_DOMAIN="$MCP_DOMAIN" PG_HOST="$PG_HOST" PG_PORT="$PG_PORT" \
+PG_DB_APIM="$PG_DB_APIM" PG_DB_SHARED="$PG_DB_SHARED" \
+PG_USER="$PG_USER" PG_PASSWORD="$PG_PASSWORD" \
+python3 - "$TOML" <<'PYEOF'
+import os
+import re
+import sys
+
+path = sys.argv[1]
+with open(path) as f:
+    content = f.read()
+
+env = os.environ
+hostname = env["MCP_DOMAIN"]
+
+# hostname público — usado por APIM para generar URLs de la gateway/consolas
+content = re.sub(r'(?m)^hostname\s*=.*$', f'hostname = "{hostname}"', content, count=1)
+
+def pg_block(db_name, db_user, db_password):
+    return (
+        f'type = "postgre"\n'
+        f'url = "jdbc:postgresql://{env["PG_HOST"]}:{env["PG_PORT"]}/{db_name}"\n'
+        f'username = "{db_user}"\n'
+        f'password = "{db_password}"\n'
+        f'driver = "org.postgresql.Driver"\n'
+        f'validationQuery = "SELECT 1"\n'
+    )
+
+def replace_block(content, header, new_body):
+    pattern = re.compile(rf'(\[{re.escape(header)}\]\n)(?:(?!\[).*\n?)*', re.MULTILINE)
+    replacement = f'[{header}]\n{new_body}'
+    if pattern.search(content):
+        return pattern.sub(replacement, content, count=1)
+    return content.rstrip('\n') + '\n\n' + replacement
+
+content = replace_block(content, "database.apim_db", pg_block(env["PG_DB_APIM"], env["PG_USER"], env["PG_PASSWORD"]))
+content = replace_block(content, "database.shared_db", pg_block(env["PG_DB_SHARED"], env["PG_USER"], env["PG_PASSWORD"]))
+
+with open(path, "w") as f:
+    f.write(content)
+PYEOF
+
+log "deployment.toml actualizado: hostname=$MCP_DOMAIN, database.apim_db y database.shared_db → PostgreSQL externa"
+log "PENDIENTE fuera de este script (clase 🔴): [apim.jwt] + Key Manager federado Dnato"
+log "  (ADR-008/ADR-009) — ver doc/identity/apim-keymanager-dnato.md antes de dar de alta el primer cliente"
+
+# ── Heap sizes ─────────────────────────────────────────────────────
+API_SH="$APIM_HOME/bin/api-manager.sh"
+if grep -qE -- '-Xm[sx][0-9]+[mMgG]' "$API_SH" 2>/dev/null; then
+  sed -i -E "s/-Xms[0-9]+[mMgG]/-Xms$APIM_XMS/g; s/-Xmx[0-9]+[mMgG]/-Xmx$APIM_XMX/g" "$API_SH"
+  log "Heap del APIM ajustado en api-manager.sh: -Xms$APIM_XMS -Xmx$APIM_XMX"
+else
+  log "AVISO: no se encontraron flags -Xms/-Xmx en api-manager.sh — ajustar heap manualmente"
+fi
+
+# ── Permisos y systemd ─────────────────────────────────────────────
+chown -R "$WSO2_USER:$WSO2_USER" "$APIM_HOME"
+
+sed -e "s#{{APIM_HOME}}#$APIM_HOME#g" -e "s#{{WSO2_USER}}#$WSO2_USER#g" \
+  "$SCRIPT_DIR/systemd/wso2am.service" > /etc/systemd/system/wso2am.service
+systemctl daemon-reload
+systemctl enable wso2am.service
+
+log ""
+log "=== install-apim.sh COMPLETADO ==="
+log "Servicio wso2am instalado y habilitado (NO se inicia automáticamente)."
+log "Para arrancar: systemctl start wso2am && journalctl -u wso2am -f"

--- a/deploy/gcp/install-mi.sh
+++ b/deploy/gcp/install-mi.sh
@@ -71,10 +71,27 @@ else
   log "AVISO: no se encontraron flags -Xms/-Xmx en micro-integrator.sh — ajustar heap manualmente"
 fi
 
+# ── JAVA_HOME (JDK 21 requerido por WSO2 4.6.0 — ver doc/v3/deployment-gcp.md §4) ──
+# systemd no lee /etc/profile.d, así que hace falta resolver JAVA_HOME acá y
+# escribirlo explícitamente en el unit (a diferencia de DEV, que lo setea en
+# el perfil de shell — ver doc/infra/wso2-install.md).
+if [ -n "${JAVA_HOME:-}" ] && [ -x "$JAVA_HOME/bin/java" ]; then
+  JAVA_HOME_RESOLVED="$JAVA_HOME"
+else
+  JAVA_BIN="$(command -v java || true)"
+  [ -n "$JAVA_BIN" ] || die "No se encontró Java. Instalar JDK 21 Temurin primero (doc/v3/deployment-gcp.md §4)."
+  JAVA_BIN="$(readlink -f "$JAVA_BIN")"
+  JAVA_HOME_RESOLVED="$(dirname "$(dirname "$JAVA_BIN")")"
+fi
+"$JAVA_HOME_RESOLVED/bin/java" -version 2>&1 | grep -q '"21\.' \
+  || die "Se requiere JDK 21 (WSO2 4.6.0) — detectado: $("$JAVA_HOME_RESOLVED/bin/java" -version 2>&1 | head -1)"
+log "JAVA_HOME detectado: $JAVA_HOME_RESOLVED (JDK 21 verificado)"
+
 # ── Permisos y systemd ─────────────────────────────────────────────
 chown -R "$WSO2_USER:$WSO2_USER" "$MI_HOME"
 
 sed -e "s#{{MI_HOME}}#$MI_HOME#g" -e "s#{{WSO2_USER}}#$WSO2_USER#g" \
+    -e "s#{{JAVA_HOME}}#$JAVA_HOME_RESOLVED#g" \
   "$SCRIPT_DIR/systemd/wso2mi.service" > /etc/systemd/system/wso2mi.service
 systemctl daemon-reload
 systemctl enable wso2mi.service

--- a/deploy/gcp/install-mi.sh
+++ b/deploy/gcp/install-mi.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# install-mi.sh
+# Instalación NATIVA (sin Docker) de WSO2 Micro Integrator en la VM de GCP.
+# Aplica ADR-011: descomprime el .zip, deja el heap del MI en su mínimo
+# funcional (el grueso de RAM va al APIM — ver install-apim.sh), y deja el
+# servicio corriendo bajo systemd.
+#
+# Fuera de alcance de este script (ver doc/v3/deployment-gcp.md):
+#   - Deploy del .car (ToolsAPIProject) — se copia a carbonapps/ por separado,
+#     igual que en DEV (ver scripts/dev/setup-mi-b4-car-deploy.sh).
+#   - Migración de las DataServices de negocio (MySQL → PostgreSQL): las
+#     datasources del proyecto (AssetPlannerDataSource, ToolsDataSource)
+#     están embebidas en el .car y se reconfiguran ahí, no en esta VM.
+#     Ver doc/identity/dataservices-remediation-phase-a.md.
+#
+# PRE:
+#   - deploy/gcp/.env presente (copiar de .env.example y completar)
+#   - .zip de WSO2 MI descargado manualmente desde wso2.com en MI_ZIP_PATH
+# USO: sudo ./install-mi.sh   (en la VM GCP)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="$SCRIPT_DIR/.env"
+
+log() { echo "[install-mi] $*"; }
+die() { echo "[ERROR] $*" >&2; exit 1; }
+
+[ -f "$ENV_FILE" ] || die "No se encontró $ENV_FILE — copiar .env.example y completar"
+set -a
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+set +a
+
+for var in MI_ZIP_PATH MI_HOME MI_XMS MI_XMX; do
+  [ -n "${!var:-}" ] || die "Falta $var en .env"
+done
+
+[ -f "$MI_ZIP_PATH" ] || die "No se encontró el zip de MI en $MI_ZIP_PATH"
+
+WSO2_USER="${WSO2_SYSTEM_USER:-wso2carbon}"
+INSTALL_PARENT="$(dirname "$MI_HOME")"
+
+# ── Usuario de sistema dedicado (compartido con el APIM) ──────────
+if ! id "$WSO2_USER" >/dev/null 2>&1; then
+  log "Creando usuario de sistema $WSO2_USER..."
+  useradd --system --no-create-home --shell /usr/sbin/nologin "$WSO2_USER"
+fi
+
+# ── Descompresión ─────────────────────────────────────────────────
+if [ -d "$MI_HOME" ]; then
+  log "AVISO: $MI_HOME ya existe — se omite la descompresión (instalación existente)"
+else
+  log "Descomprimiendo $MI_ZIP_PATH en $INSTALL_PARENT..."
+  mkdir -p "$INSTALL_PARENT"
+  UNZIP_TMP="$(mktemp -d)"
+  unzip -q "$MI_ZIP_PATH" -d "$UNZIP_TMP"
+  UNZIPPED_DIR="$(find "$UNZIP_TMP" -mindepth 1 -maxdepth 1 -type d | head -1)"
+  [ -n "$UNZIPPED_DIR" ] || die "El zip no contiene el directorio esperado"
+  mv "$UNZIPPED_DIR" "$MI_HOME"
+  rmdir "$UNZIP_TMP" 2>/dev/null || true
+fi
+find "$MI_HOME/bin" -iname "*.sh" -exec chmod +x {} \;
+
+# ── Heap size (mínimo funcional — default de fábrica es -Xms256m -Xmx1024m) ──
+MI_SH="$MI_HOME/bin/micro-integrator.sh"
+if grep -qE -- '-Xm[sx][0-9]+[mMgG]' "$MI_SH" 2>/dev/null; then
+  sed -i -E "s/-Xms[0-9]+[mMgG]/-Xms$MI_XMS/g; s/-Xmx[0-9]+[mMgG]/-Xmx$MI_XMX/g" "$MI_SH"
+  log "Heap del MI ajustado en micro-integrator.sh: -Xms$MI_XMS -Xmx$MI_XMX"
+else
+  log "AVISO: no se encontraron flags -Xms/-Xmx en micro-integrator.sh — ajustar heap manualmente"
+fi
+
+# ── Permisos y systemd ─────────────────────────────────────────────
+chown -R "$WSO2_USER:$WSO2_USER" "$MI_HOME"
+
+sed -e "s#{{MI_HOME}}#$MI_HOME#g" -e "s#{{WSO2_USER}}#$WSO2_USER#g" \
+  "$SCRIPT_DIR/systemd/wso2mi.service" > /etc/systemd/system/wso2mi.service
+systemctl daemon-reload
+systemctl enable wso2mi.service
+
+log ""
+log "=== install-mi.sh COMPLETADO ==="
+log "Servicio wso2mi instalado y habilitado (NO se inicia automáticamente)."
+log "Recordar copiar el .car actualizado a $MI_HOME/repository/deployment/server/carbonapps/ antes de arrancar."
+log "Para arrancar: systemctl start wso2mi && journalctl -u wso2mi -f"

--- a/deploy/gcp/reverse-proxy/Caddyfile
+++ b/deploy/gcp/reverse-proxy/Caddyfile
@@ -1,0 +1,28 @@
+# Caddyfile — reverse proxy nativo para mcp.cloudtrazalog.com (ADR-011 #7, #9)
+#
+# TLS Let's Encrypt automático (HTTP-01 sobre :80, sirve en :443).
+# Solo expone el Gateway del APIM (:8243). La consola de administración
+# (:9443) NUNCA se expone acá — se accede por red interna/túnel (ADR-011 #9).
+#
+# Variables tomadas del entorno del servicio systemd `caddy`
+# (EnvironmentFile=/etc/caddy/gcp.env, ver setup-reverse-proxy.sh).
+
+{
+	email {$LETSENCRYPT_EMAIL}
+}
+
+{$MCP_DOMAIN} {
+	# El Gateway usa certificado self-signed en localhost:8243 (ver
+	# doc/infra/wso2-install.md). Válido acá porque el salto Caddy→APIM
+	# es loopback, nunca sale de la VM; el cliente solo ve el cert de
+	# Let's Encrypt de Caddy.
+	reverse_proxy https://127.0.0.1:8243 {
+		transport http {
+			tls_insecure_skip_verify
+		}
+	}
+
+	log {
+		output file /var/log/caddy/mcp-access.log
+	}
+}

--- a/deploy/gcp/setup-reverse-proxy.sh
+++ b/deploy/gcp/setup-reverse-proxy.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# setup-reverse-proxy.sh
+# Instala Caddy nativo (repo oficial, sin Docker) y lo configura como reverse
+# proxy TLS para mcp.cloudtrazalog.com → APIM Gateway (:8243). Aplica ADR-011
+# #7 (Let's Encrypt automático) y #9 (9443 nunca público).
+#
+# Fuente de instalación: repo oficial de Caddy en Cloudsmith
+# (https://caddyserver.com/docs/install#debian-ubuntu-raspbian).
+#
+# PRE: deploy/gcp/.env presente, con MCP_DOMAIN y LETSENCRYPT_EMAIL completos.
+#      DNS de MCP_DOMAIN ya apuntando a la IP pública de esta VM (paso manual
+#      de Rodolfo en su consola de GCP — ver doc/v3/deployment-gcp.md).
+#      Firewall del proyecto GCP con 80/443 abiertos y 9443 cerrado al público.
+# USO: sudo ./setup-reverse-proxy.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="$SCRIPT_DIR/.env"
+
+log() { echo "[reverse-proxy] $*"; }
+die() { echo "[ERROR] $*" >&2; exit 1; }
+
+[ -f "$ENV_FILE" ] || die "No se encontró $ENV_FILE — copiar .env.example y completar"
+set -a
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+set +a
+
+for var in MCP_DOMAIN LETSENCRYPT_EMAIL; do
+  [ -n "${!var:-}" ] || die "Falta $var en .env"
+done
+
+# ── Instalación de Caddy (repo oficial, si no está instalado) ────
+if ! command -v caddy >/dev/null 2>&1; then
+  log "Instalando Caddy desde el repo oficial (Cloudsmith)..."
+  apt-get update -y
+  apt-get install -y debian-keyring debian-archive-keyring apt-transport-https curl
+  curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' \
+    | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+  curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' \
+    | tee /etc/apt/sources.list.d/caddy-stable.list
+  apt-get update -y
+  apt-get install -y caddy
+else
+  log "Caddy ya está instalado ($(caddy version))"
+fi
+
+# ── Config: Caddyfile + env file para el servicio systemd ────────
+cp "$SCRIPT_DIR/reverse-proxy/Caddyfile" /etc/caddy/Caddyfile
+
+cat > /etc/caddy/gcp.env <<EOF
+MCP_DOMAIN=$MCP_DOMAIN
+LETSENCRYPT_EMAIL=$LETSENCRYPT_EMAIL
+EOF
+chmod 600 /etc/caddy/gcp.env
+
+mkdir -p /etc/systemd/system/caddy.service.d
+cat > /etc/systemd/system/caddy.service.d/override.conf <<'EOF'
+[Service]
+EnvironmentFile=/etc/caddy/gcp.env
+EOF
+
+mkdir -p /var/log/caddy
+chown caddy:caddy /var/log/caddy
+
+systemctl daemon-reload
+systemctl enable caddy
+systemctl restart caddy
+
+log ""
+log "=== setup-reverse-proxy.sh COMPLETADO ==="
+log "Caddy escuchando en :80/:443 para $MCP_DOMAIN, proxy a https://127.0.0.1:8243"
+log "Verificar: systemctl status caddy && curl -I https://$MCP_DOMAIN"
+log "Recordar: el firewall del proyecto GCP debe abrir 80/443 y NO exponer 9443 (ADR-011 #9)"

--- a/deploy/gcp/setup-reverse-proxy.sh
+++ b/deploy/gcp/setup-reverse-proxy.sh
@@ -4,8 +4,9 @@
 # proxy TLS para mcp.cloudtrazalog.com → APIM Gateway (:8243). Aplica ADR-011
 # #7 (Let's Encrypt automático) y #9 (9443 nunca público).
 #
-# Fuente de instalación: repo oficial de Caddy en Cloudsmith
-# (https://caddyserver.com/docs/install#debian-ubuntu-raspbian).
+# SO objetivo: Rocky Linux 9 (IDR-001 en TRAZALOG_v3_MCP_ARCHITECTURE.md §9-10 —
+# no Ubuntu ni CentOS 7). Fuente de instalación: repo oficial de Caddy vía Copr
+# (https://caddyserver.com/docs/install#fedora-redhat-centos).
 #
 # PRE: deploy/gcp/.env presente, con MCP_DOMAIN y LETSENCRYPT_EMAIL completos.
 #      DNS de MCP_DOMAIN ya apuntando a la IP pública de esta VM (paso manual
@@ -31,17 +32,12 @@ for var in MCP_DOMAIN LETSENCRYPT_EMAIL; do
   [ -n "${!var:-}" ] || die "Falta $var en .env"
 done
 
-# ── Instalación de Caddy (repo oficial, si no está instalado) ────
+# ── Instalación de Caddy (repo oficial vía Copr, si no está instalado) ──
 if ! command -v caddy >/dev/null 2>&1; then
-  log "Instalando Caddy desde el repo oficial (Cloudsmith)..."
-  apt-get update -y
-  apt-get install -y debian-keyring debian-archive-keyring apt-transport-https curl
-  curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' \
-    | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
-  curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' \
-    | tee /etc/apt/sources.list.d/caddy-stable.list
-  apt-get update -y
-  apt-get install -y caddy
+  log "Instalando Caddy desde el repo oficial (Copr, Fedora/RHEL/Rocky)..."
+  dnf install -y 'dnf-command(copr)'
+  dnf copr enable -y @caddy/caddy
+  dnf install -y caddy
 else
   log "Caddy ya está instalado ($(caddy version))"
 fi

--- a/deploy/gcp/setup-reverse-proxy.sh
+++ b/deploy/gcp/setup-reverse-proxy.sh
@@ -34,8 +34,8 @@ done
 
 # ── Instalación de Caddy (repo oficial vía Copr, si no está instalado) ──
 if ! command -v caddy >/dev/null 2>&1; then
-  log "Instalando Caddy desde el repo oficial (Copr, Fedora/RHEL/Rocky)..."
-  dnf install -y 'dnf-command(copr)'
+  log "Instalando Caddy desde el repo oficial (Copr, sección CentOS/RHEL de caddyserver.com/docs/install)..."
+  dnf install -y dnf-plugins-core
   dnf copr enable -y @caddy/caddy
   dnf install -y caddy
 else

--- a/deploy/gcp/systemd/wso2am.service
+++ b/deploy/gcp/systemd/wso2am.service
@@ -7,6 +7,7 @@ Wants=network-online.target
 Type=forking
 User={{WSO2_USER}}
 Group={{WSO2_USER}}
+Environment="JAVA_HOME={{JAVA_HOME}}"
 WorkingDirectory={{APIM_HOME}}
 ExecStart={{APIM_HOME}}/bin/api-manager.sh start
 ExecStop={{APIM_HOME}}/bin/api-manager.sh stop

--- a/deploy/gcp/systemd/wso2am.service
+++ b/deploy/gcp/systemd/wso2am.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=WSO2 API Manager 4.6.0 (Trazalog v3 - ADR-011)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=forking
+User={{WSO2_USER}}
+Group={{WSO2_USER}}
+WorkingDirectory={{APIM_HOME}}
+ExecStart={{APIM_HOME}}/bin/api-manager.sh start
+ExecStop={{APIM_HOME}}/bin/api-manager.sh stop
+PIDFile={{APIM_HOME}}/wso2carbon.pid
+Restart=on-failure
+RestartSec=15
+TimeoutStartSec=300
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/gcp/systemd/wso2mi.service
+++ b/deploy/gcp/systemd/wso2mi.service
@@ -7,6 +7,7 @@ Wants=network-online.target
 Type=forking
 User={{WSO2_USER}}
 Group={{WSO2_USER}}
+Environment="JAVA_HOME={{JAVA_HOME}}"
 WorkingDirectory={{MI_HOME}}
 ExecStart={{MI_HOME}}/bin/micro-integrator.sh start
 ExecStop={{MI_HOME}}/bin/micro-integrator.sh stop

--- a/deploy/gcp/systemd/wso2mi.service
+++ b/deploy/gcp/systemd/wso2mi.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=WSO2 Micro Integrator (Trazalog v3 - ADR-011)
+After=network-online.target wso2am.service
+Wants=network-online.target
+
+[Service]
+Type=forking
+User={{WSO2_USER}}
+Group={{WSO2_USER}}
+WorkingDirectory={{MI_HOME}}
+ExecStart={{MI_HOME}}/bin/micro-integrator.sh start
+ExecStop={{MI_HOME}}/bin/micro-integrator.sh stop
+PIDFile={{MI_HOME}}/wso2carbon.pid
+Restart=on-failure
+RestartSec=15
+TimeoutStartSec=180
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target

--- a/doc/v3/STATE.md
+++ b/doc/v3/STATE.md
@@ -25,7 +25,7 @@
 
 ### Próxima acción
 
-Rodolfo ya confirmó el sizing (`e2-medium`, ~US$24-25/mes) y aclaró que las VMs del proyecto viven en "Trazalog" en GCP. Falta que confirme la región/VPC exacta donde viven Dnato y PostgreSQL (ver `doc/v3/deployment-gcp.md` §4 paso 1) y que ejecute el checklist de esa sección en su consola de GCP. En paralelo, sigue pendiente que responda las 5 preguntas abiertas de `doc/v3/sprint-3-relevamiento-estado.md` (especialmente el riesgo de seguridad en `ALMDataService` — §2).
+Rodolfo ya confirmó el sizing (`e2-medium`, ~US$24-25/mes) y la zona (`us-east1-b`, proyecto GCP "Trazalog", misma zona que Dnato/PostgreSQL/VM legacy 4.4). Queda que ejecute el checklist de `doc/v3/deployment-gcp.md` §4 en su consola de GCP para crear la VM. En paralelo, sigue pendiente que responda las 5 preguntas abiertas de `doc/v3/sprint-3-relevamiento-estado.md` (especialmente el riesgo de seguridad en `ALMDataService` — §2).
 
 ### Decisiones recientes (últimas 5)
 

--- a/doc/v3/STATE.md
+++ b/doc/v3/STATE.md
@@ -20,7 +20,7 @@
 
 | ID | Descripción | Clase | Estado | Rama / PR |
 |---|---|---|---|---|
-| E7-INFRA-01/02 | Sizing VM GCP + scripts instalación nativa WSO2 (ADR-011) | 🟡 | En review | `feature/e7-infra-01-02-gcp-native-deploy` — PR pendiente de apertura |
+| E7-INFRA-01/02 | Sizing VM GCP + scripts instalación nativa WSO2 (ADR-011) | 🟡 | En review | `feature/e7-infra-01-02-gcp-native-deploy` — PR #403 |
 | E1-API-20 | Relevamiento de estado para dimensionar Sprint 3 (3 frentes) | 🟢 | Completada | `docs/e1-api-20-sprint3-relevamiento-estado` — PR pendiente de abrir |
 
 ### Próxima acción
@@ -31,7 +31,7 @@ Rodolfo revisa el PR de E7-INFRA-01/02: confirma el gasto mensual implicado por 
 
 | Fecha | Decisión | Referencia |
 |---|---|---|
-| 2026-07-21 | Sizing de la VM GCP: `e2-standard-2` (2 vCPU/8GB) — `e2-micro`/`e2-small` insuficientes por RAM, `e2-medium` empata justo con el mínimo oficial del APIM sin margen para el MI | `doc/v3/deployment-gcp.md`, PR E7-INFRA-01/02 |
+| 2026-07-21 | Sizing de la VM GCP: `e2-standard-2` (2 vCPU/8GB) — `e2-micro`/`e2-small` insuficientes por RAM, `e2-medium` empata justo con el mínimo oficial del APIM sin margen para el MI | `doc/v3/deployment-gcp.md`, PR #403 |
 | 2026-07-16 | Relevamiento Sprint 3 completo: Mantenimiento con diseño listo para implementar, Almacenes con lógica de negocio ya existente pero gap de seguridad multi-tenant sin resolver, Despliegue GCP arranca de cero en artefactos | `doc/v3/sprint-3-relevamiento-estado.md` |
 
 ### Bloqueos

--- a/doc/v3/STATE.md
+++ b/doc/v3/STATE.md
@@ -31,6 +31,7 @@ Rodolfo ya confirmó el sizing (`e2-medium`, ~US$24-25/mes) y la zona (`us-east1
 
 | Fecha | Decisión | Referencia |
 |---|---|---|
+| 2026-07-24 | Corregido el SO de la VM GCP: `Rocky Linux 9` (no Ubuntu, error de la v1 del doc). Ya estaba decidido en IDR-001 (`TRAZALOG_v3_MCP_ARCHITECTURE.md` §9-10) por incompatibilidad de CentOS 7/glibc con JDK 21 — no es una decisión nueva | `doc/v3/deployment-gcp.md`, PR #403 |
 | 2026-07-21 | Sizing final de la VM GCP: `e2-medium` (2 vCPU/4GB), no `e2-standard-2`. Rodolfo priorizó costo (~US$24/mes) + volumen real (1-2 usuarios) por sobre el mínimo "de catálogo" de WSO2, con heaps chicos ya validados en su DEV | `doc/v3/deployment-gcp.md`, PR #403 |
 | 2026-07-16 | Relevamiento Sprint 3 completo: Mantenimiento con diseño listo para implementar, Almacenes con lógica de negocio ya existente pero gap de seguridad multi-tenant sin resolver, Despliegue GCP arranca de cero en artefactos | `doc/v3/sprint-3-relevamiento-estado.md` |
 

--- a/doc/v3/STATE.md
+++ b/doc/v3/STATE.md
@@ -12,27 +12,31 @@
 
 ---
 
-**Sprint actual:** Sprint 3 — Activación early adopter minero (dimensionamiento)
-**Objetivo del sprint:** Relevar estado real de los 3 frentes (Mantenimiento, Almacenes, Despliegue GCP) para que el PM priorice con datos reales antes de arrancar implementación.
-**Última actualización:** 2026-07-16 por Claude Code (E1-API-20)
+**Sprint actual:** Sprint 3 — Activación early adopter minero
+**Objetivo del sprint:** Reemplazar ngrok por un despliegue estable en GCP (ADR-011) y cerrar la deuda técnica pendiente antes de activar al primer cliente early adopter.
+**Última actualización:** 2026-07-21 por Claude Code (E7-INFRA-01/02)
 
 ### Tareas activas
 
 | ID | Descripción | Clase | Estado | Rama / PR |
 |---|---|---|---|---|
+| E7-INFRA-01/02 | Sizing VM GCP + scripts instalación nativa WSO2 (ADR-011) | 🟡 | En review | `feature/e7-infra-01-02-gcp-native-deploy` — PR pendiente de apertura |
 | E1-API-20 | Relevamiento de estado para dimensionar Sprint 3 (3 frentes) | 🟢 | Completada | `docs/e1-api-20-sprint3-relevamiento-estado` — PR pendiente de abrir |
 
 ### Próxima acción
 
-Rodolfo revisa `doc/v3/sprint-3-relevamiento-estado.md` y responde las 5 preguntas abiertas de la sección 5 (especialmente el riesgo de seguridad en `ALMDataService` — §2 del doc) antes de asignar trabajo de implementación del Sprint 3.
+Rodolfo revisa el PR de E7-INFRA-01/02: confirma el gasto mensual implicado por `e2-standard-2` (tensión con ADR-005, ver `doc/v3/deployment-gcp.md` §1.4) y la región/VPC donde ya viven Dnato y PostgreSQL. Si aprueba, ejecuta el checklist de la §4 de ese documento en su consola de GCP. En paralelo, sigue pendiente que responda las 5 preguntas abiertas de `doc/v3/sprint-3-relevamiento-estado.md` (especialmente el riesgo de seguridad en `ALMDataService` — §2).
 
 ### Decisiones recientes (últimas 5)
 
 | Fecha | Decisión | Referencia |
 |---|---|---|
+| 2026-07-21 | Sizing de la VM GCP: `e2-standard-2` (2 vCPU/8GB) — `e2-micro`/`e2-small` insuficientes por RAM, `e2-medium` empata justo con el mínimo oficial del APIM sin margen para el MI | `doc/v3/deployment-gcp.md`, PR E7-INFRA-01/02 |
 | 2026-07-16 | Relevamiento Sprint 3 completo: Mantenimiento con diseño listo para implementar, Almacenes con lógica de negocio ya existente pero gap de seguridad multi-tenant sin resolver, Despliegue GCP arranca de cero en artefactos | `doc/v3/sprint-3-relevamiento-estado.md` |
 
 ### Bloqueos
 
-- Ninguno para el relevamiento en sí. La implementación de escritura MCP en Almacenes queda bloqueada hasta que el PM confirme cómo resolver el aislamiento multi-tenant de `ALMDataService` (ver pregunta abierta #1 del relevamiento) — posible tema de arquitectura (🔴).
+- **Costo real de la VM elegida (~US$50-60/mes) es una excepción parcial a ADR-005** — necesita aprobación explícita de Rodolfo antes de crear la VM (ver `doc/v3/deployment-gcp.md` §1.4).
+- Config de identidad (ADR-008/009) y migración de DataServices a PostgreSQL siguen pendientes antes de poder dar de alta al primer cliente sobre esta VM — fuera de alcance de E7-INFRA-01/02.
+- La implementación de escritura MCP en Almacenes sigue bloqueada hasta que el PM confirme cómo resolver el aislamiento multi-tenant de `ALMDataService` (ver pregunta abierta #1 del relevamiento) — posible tema de arquitectura (🔴).
 

--- a/doc/v3/STATE.md
+++ b/doc/v3/STATE.md
@@ -25,13 +25,13 @@
 
 ### Próxima acción
 
-Rodolfo revisa el PR de E7-INFRA-01/02: confirma el gasto mensual implicado por `e2-standard-2` (tensión con ADR-005, ver `doc/v3/deployment-gcp.md` §1.4) y la región/VPC donde ya viven Dnato y PostgreSQL. Si aprueba, ejecuta el checklist de la §4 de ese documento en su consola de GCP. En paralelo, sigue pendiente que responda las 5 preguntas abiertas de `doc/v3/sprint-3-relevamiento-estado.md` (especialmente el riesgo de seguridad en `ALMDataService` — §2).
+Rodolfo ya confirmó el sizing (`e2-medium`, ~US$24-25/mes) y aclaró que las VMs del proyecto viven en "Trazalog" en GCP. Falta que confirme la región/VPC exacta donde viven Dnato y PostgreSQL (ver `doc/v3/deployment-gcp.md` §4 paso 1) y que ejecute el checklist de esa sección en su consola de GCP. En paralelo, sigue pendiente que responda las 5 preguntas abiertas de `doc/v3/sprint-3-relevamiento-estado.md` (especialmente el riesgo de seguridad en `ALMDataService` — §2).
 
 ### Decisiones recientes (últimas 5)
 
 | Fecha | Decisión | Referencia |
 |---|---|---|
-| 2026-07-21 | Sizing de la VM GCP: `e2-standard-2` (2 vCPU/8GB) — `e2-micro`/`e2-small` insuficientes por RAM, `e2-medium` empata justo con el mínimo oficial del APIM sin margen para el MI | `doc/v3/deployment-gcp.md`, PR #403 |
+| 2026-07-21 | Sizing final de la VM GCP: `e2-medium` (2 vCPU/4GB), no `e2-standard-2`. Rodolfo priorizó costo (~US$24/mes) + volumen real (1-2 usuarios) por sobre el mínimo "de catálogo" de WSO2, con heaps chicos ya validados en su DEV | `doc/v3/deployment-gcp.md`, PR #403 |
 | 2026-07-16 | Relevamiento Sprint 3 completo: Mantenimiento con diseño listo para implementar, Almacenes con lógica de negocio ya existente pero gap de seguridad multi-tenant sin resolver, Despliegue GCP arranca de cero en artefactos | `doc/v3/sprint-3-relevamiento-estado.md` |
 
 ### Bloqueos

--- a/doc/v3/deployment-gcp.md
+++ b/doc/v3/deployment-gcp.md
@@ -98,6 +98,15 @@ VM GCP nueva (e2-medium, solo WSO2 nativo)
 
 Pasos manuales — Claude Code no tiene acceso a la consola de GCP y no ejecuta nada de esto.
 
+> **Cómo correr los comandos `gcloud` de este checklist sin instalar nada:** los pasos 3 y 5 usan `gcloud`. No hace falta instalarlo en ninguna máquina — se usa **Cloud Shell**, la terminal integrada en el navegador de la consola de GCP:
+> 1. Ir a [console.cloud.google.com](https://console.cloud.google.com) y loguearse con la cuenta de Trazalog.
+> 2. Arriba a la izquierda, click en el selector de proyecto → buscar **"Trazalog"** → seleccionarlo. Confirmar que la barra superior queda con ese proyecto activo.
+> 3. Arriba a la derecha, click en el ícono de terminal (`>_`, "Activate Cloud Shell"). Esperar a que inicialice.
+> 4. Verificar el proyecto activo: `gcloud config get-value project` (debe mostrar el ID del proyecto Trazalog).
+> 5. Pegar ahí los comandos `gcloud compute...` de los pasos 3 y 5, uno por vez.
+>
+> Estos comandos son de **configuración del proyecto** (IP, firewall) — se corren desde Cloud Shell, **no por SSH dentro de la VM nueva**. El acceso por SSH a la VM recién aparece en los pasos 6-7 (instalar JDK, correr los scripts de `deploy/gcp/`).
+
 1. ~~Confirmar región/VPC~~ **Confirmado: `us-east1-b`** (proyecto GCP "Trazalog") — misma zona donde ya viven Dnato, PostgreSQL y la VM legacy con WSO2 4.4. Crear la VM nueva ahí (evita latencia y cargos de tráfico inter-región/inter-zona).
 2. **Crear la VM**: tipo `e2-medium`, zona `us-east1-b`, imagen **Rocky Linux 9** (decisión ya tomada en IDR-001, ver 1.1 — no Ubuntu ni CentOS 7), disco 20 GB pd-standard.
    - **Ojo con la variante de imagen**: en el selector de GCP puede aparecer "Rocky Linux 10 optimized for GCP with out-of-tree GVNIC (GVE) Support". **No usar la 10** — la [matriz oficial de compatibilidad de WSO2 4.6.0](https://apim.docs.wso2.com/en/4.6.0/install-and-setup/setup/reference/product-compatibility/) lista `Rocky Linux 8.7`/`9.3` como testeados; Rocky 10/RHEL 10 no figura ahí. GVNIC solo aporta en tráfico intensivo o familias de máquina específicas (C3, N2D, Tau T2D) — irrelevante para un `e2-medium` de 1-2 usuarios. Si existe una variante "Rocky Linux 9 optimized for GCP" (con o sin GVNIC), esa sí sirve igual.

--- a/doc/v3/deployment-gcp.md
+++ b/doc/v3/deployment-gcp.md
@@ -100,6 +100,7 @@ Pasos manuales — Claude Code no tiene acceso a la consola de GCP y no ejecuta 
 
 1. ~~Confirmar región/VPC~~ **Confirmado: `us-east1-b`** (proyecto GCP "Trazalog") — misma zona donde ya viven Dnato, PostgreSQL y la VM legacy con WSO2 4.4. Crear la VM nueva ahí (evita latencia y cargos de tráfico inter-región/inter-zona).
 2. **Crear la VM**: tipo `e2-medium`, zona `us-east1-b`, imagen **Rocky Linux 9** (decisión ya tomada en IDR-001, ver 1.1 — no Ubuntu ni CentOS 7), disco 20 GB pd-standard.
+   - **Ojo con la variante de imagen**: en el selector de GCP puede aparecer "Rocky Linux 10 optimized for GCP with out-of-tree GVNIC (GVE) Support". **No usar la 10** — la [matriz oficial de compatibilidad de WSO2 4.6.0](https://apim.docs.wso2.com/en/4.6.0/install-and-setup/setup/reference/product-compatibility/) lista `Rocky Linux 8.7`/`9.3` como testeados; Rocky 10/RHEL 10 no figura ahí. GVNIC solo aporta en tráfico intensivo o familias de máquina específicas (C3, N2D, Tau T2D) — irrelevante para un `e2-medium` de 1-2 usuarios. Si existe una variante "Rocky Linux 9 optimized for GCP" (con o sin GVNIC), esa sí sirve igual.
 3. **Reservar IP pública estática** y asociarla a la VM.
 4. **DNS**: apuntar `mcp.cloudtrazalog.com` (registro A) a la IP estática reservada en el paso 3.
 5. **Firewall del proyecto GCP**:

--- a/doc/v3/deployment-gcp.md
+++ b/doc/v3/deployment-gcp.md
@@ -15,18 +15,19 @@
 | WSO2 API Manager 4.6.0 (all-in-one) | **4 GB** (2 GB heap JVM + 2 GB SO) | 2 cores (3 GHz dual-core Xeon/Opteron o equiv.) | [Installation Prerequisites — APIM 4.6.0](https://apim.docs.wso2.com/en/4.6.0/install-and-setup/install/installation-prerequisites/) |
 | WSO2 Micro Integrator 4.x | Liviano — heap por defecto de fábrica `-Xms256m -Xmx1024m` en `bin/micro-integrator.sh` (footprint total ≈1 GB, reducido respecto a las ~4 GB de la generación EI anterior) | 1-2 cores compartidos | Confirmado en el script de arranque distribuido por WSO2; ver también `scripts/dev/setup-mi-b4-car-deploy.sh` de este repo (DEV corre MI 4.5.0 así) |
 
-**Conclusión:** correr APIM + MI + reverse proxy + SO en la misma VM necesita, como piso real, **RAM(APIM oficial) + RAM(MI liviano) + margen de SO/red** ≈ 4 GB + 1 GB + 1-2 GB ≈ **6-7 GB mínimo**, no los 4 GB que alcanzarían para el APIM solo.
+**Estos son los mínimos "de catálogo" de WSO2**, pensados para un ambiente de producción genérico con carga concurrente real. No son el punto de partida correcto para dimensionar el piloto: Rodolfo ya corre APIM+MI en su máquina de desarrollo con heaps de fábrica (`MI: -Xms256m -Xmx1024m`, sin tocar nada) y le anda bien. El early adopter va a tener **1-2 usuarios**, no la carga concurrente que esos mínimos oficiales asumen. Se prioriza ese dato empírico + el volumen real esperado por sobre el catálogo oficial (ver decisión en 1.4).
 
 ### 1.2 Comparación de tiers E2 (specs verificadas contra `docs.cloud.google.com`)
 
-| Tier | vCPU | RAM | Precio aprox.* (on-demand, us-central1) | ¿Aguanta el stack? |
+| Tier | vCPU | RAM | Precio aprox.* (on-demand, us-central1) | ¿Aguanta 1-2 usuarios piloto? |
 |---|---|---|---|---|
-| `e2-micro` | 2 vCPU compartidas (0.25 sustenido) | **1 GB** | Cubierto por Always Free (ver 1.3) | ❌ No. Por debajo del mínimo oficial del APIM solo (4 GB) |
-| `e2-small` | 2 vCPU compartidas (0.5 sustenido) | **2 GB** | ≈ US$12-15/mes | ❌ No. La mitad del mínimo oficial del APIM solo |
-| `e2-medium` | 2 vCPU compartidas (1.0 sustenido) | **4 GB** | ≈ US$24-25/mes | ⚠️ Al límite exacto del mínimo oficial del APIM **solo**, sin margen para el MI, el reverse proxy, sshd ni el SO. Riesgo real de OOM/lentitud — no recomendado para un despliegue de cara al cliente |
-| **`e2-standard-2`** | **2 vCPU dedicadas** | **8 GB** | ≈ US$48-52/mes | ✅ Sí. Cubre el mínimo oficial del APIM con margen, el MI en su heap liviano, y deja ~3-4 GB para SO/reverse proxy/monitoreo |
+| `e2-micro` | 2 vCPU compartidas (0.25 sustenido) | **1 GB** | Cubierto por Always Free (ver 1.3) | ❌ No. Ni siquiera un solo heap de MI (`Xmx1024m`) entra cómodo, sin contar el APIM ni el SO |
+| **`e2-medium`** | **2 vCPU compartidas (1.0 sustenido)** | **4 GB** | ≈ US$24-25/mes | ✅ Sí, con heaps chicos (ver 1.5) y aceptando el riesgo ya previsto en ADR-011 ("sizing ajustado", escalable sin reinstalar) |
+| `e2-standard-2` | 2 vCPU dedicadas | 8 GB | ≈ US$48-52/mes | Sobredimensionado para 1-2 usuarios — se descarta por costo (ver 1.4) |
 
 \* Precios de referencia obtenidos de trackers de terceros (economize.cloud, cloudprice.net, vantage.sh) al momento de esta investigación (2026-07-21). **Cambian seguido y varían por región** — reconfirmar el número exacto en [cloud.google.com/products/calculator](https://cloud.google.com/products/calculator) antes de aprobar el gasto. No son los precios oficiales citados textualmente, son una referencia de orden de magnitud.
+
+`e2-small` (2 GB) se descartó directamente: ni con heaps mínimos entran dos JVMs (APIM+MI) más SO más Caddy sin arriesgar swap constante.
 
 ### 1.3 Free tier — verificado contra la doc oficial
 
@@ -38,33 +39,38 @@ Texto verbatim de la [documentación oficial Always Free](https://docs.cloud.goo
 
 ### 1.4 Decisión de sizing
 
-**Tier elegido: `e2-standard-2` (2 vCPU, 8 GB RAM).**
+**Tier elegido: `e2-medium` (2 vCPU compartidas, 4 GB RAM). Decisión de Rodolfo, no la recomendación inicial de esta investigación.**
 
-Justificación: es el primer tier que supera el mínimo oficial documentado por WSO2 para el APIM (4 GB) dejando margen real para el MI, el reverse proxy (Caddy) y el sistema operativo — `e2-medium` empata justo con el piso del APIM solo, sin ningún margen, lo cual es un riesgo inaceptable para el primer despliegue de cara a un cliente. El tipo de máquina es cambiable sin reinstalar (ADR-011, riesgo aceptado "sizing ajustado" — primer movimiento ante problemas de memoria es subir de tier).
+La primera versión de este documento recomendaba `e2-standard-2` (8 GB) siguiendo al pie de la letra el mínimo "de catálogo" que documenta WSO2 para producción genérica. Rodolfo corrigió el enfoque: el early adopter va a tener **1-2 usuarios**, no la carga concurrente que ese catálogo asume, y él mismo corre el stack en su máquina de desarrollo con heaps de fábrica sin problemas. Para ese volumen real, `e2-medium` alcanza — y cuesta la mitad (~US$24-25/mes vs. ~US$48-52/mes).
 
-**⚠️ Punto que requiere confirmación explícita de Rodolfo antes de crear la VM:**
-ADR-005 establece costo incremental **$0 hasta 2027**. El sizing mínimo viable real (`e2-standard-2`) **no es gratuito** — ronda los US$48-52/mes (a reconfirmar con el calculador oficial). El free tier de Compute Engine no alcanza para este stack bajo ninguna combinación verificada. Esto es una excepción parcial a ADR-005 que el sizing técnico no puede evitar — se documenta acá para que sea una decisión consciente y no un descubrimiento post-facto en la factura de GCP.
+Esto es exactamente el riesgo que ADR-011 ya preveía y aceptó explícitamente ("sizing ajustado: si la VM elegida queda por debajo de lo que WSO2 recomienda, puede haber lentitud... mitigación: el tipo de máquina es escalable sin reinstalar"). Se arranca con lo mínimo indispensable; si el feedback de uso real del early adopter muestra que hace falta más, se sube de tier sin tener que reinstalar nada (cambio de tipo de máquina en la consola de GCP + reinicio).
 
-### 1.5 Reparto de heap propuesto (`e2-standard-2`, 8 GB total)
+**Costo vs. ADR-005**: `e2-medium` sigue sin ser gratis (~US$24-25/mes, el free tier de GCP solo cubre `e2-micro`), pero es una excepción mucho más chica a ADR-005 que la propuesta original, y Rodolfo ya la aceptó conscientemente en esta conversación.
+
+### 1.5 Reparto de heap propuesto (`e2-medium`, 4 GB total)
 
 | Proceso | `-Xms` | `-Xmx` | Nota |
 |---|---|---|---|
-| APIM | 2g | 3g | Prioridad de RAM (ADR-011 #4). Deja margen sobre el mínimo oficial de 2 GB heap |
-| MI | 256m | 768m | Cerca del default de fábrica (`256m`/`1024m`); se recorta el `-Xmx` levemente para dejarle más margen al APIM |
-| SO + Caddy + sshd + monitoreo | — | — | Resto (~3-4 GB) sin asignar a heap, disponible como colchón |
+| MI | 256m | 1024m | Igual al default de fábrica que Rodolfo ya usa en DEV y confirmó que anda bien |
+| APIM | 512m | 1536m | Recibe algo más de RAM que el MI (ADR-011 #4 — sigue priorizando al APIM) pero muy por debajo del mínimo "de catálogo" de 2 GB heap, acorde al volumen de 1-2 usuarios |
+| SO + Caddy + sshd | — | — | Resto (~1-1.5 GB una vez descontado el overhead de JVM de ambos procesos, no solo el heap declarado) — colchón más ajustado que en un dimensionamiento de catálogo, aceptado a propósito |
 
-Configurable en [`deploy/gcp/.env`](../../deploy/gcp/.env.example) (`APIM_XMS`/`APIM_XMX`/`MI_XMS`/`MI_XMX`) sin tener que reinstalar — volver a correr `install-apim.sh` / `install-mi.sh` reaplica la config sobre una instalación existente.
+Configurable en [`deploy/gcp/.env`](../../deploy/gcp/.env.example) (`APIM_XMS`/`APIM_XMX`/`MI_XMS`/`MI_XMX`) sin tener que reinstalar — volver a correr `install-apim.sh` / `install-mi.sh` reaplica la config sobre una instalación existente. Si tras el feedback de uso hace falta más margen, el camino es subir estos valores y/o el tier de la VM, no rearmar nada desde cero.
 
 ### 1.6 Disco
 
-Ambos productos + logs necesitan holgadamente menos que los 10 GB mínimos que documenta WSO2 para el APIM solo. Se recomienda **30 GB pd-balanced** (o pd-standard si se prioriza costo sobre IOPS) — cubre APIM + MI + logs con margen para varios meses de crecimiento, a un costo marginal (unos pocos dólares/mes, verificar en el calculador).
+Ambos productos + logs necesitan holgadamente menos que los 10 GB mínimos que documenta WSO2 para el APIM solo. Se recomienda **20 GB pd-standard** — cubre APIM + MI + logs con margen para varios meses, priorizando costo (consistente con el criterio de esta sección), a un costo marginal (un par de dólares/mes, verificar en el calculador).
+
+### 1.7 Nota de contexto: la otra VM (WSO2 4.4, sin MCP)
+
+Rodolfo ya tiene otra VM en el mismo proyecto GCP corriendo WSO2 **4.4** (sin servidor MCP). Una vez cerrado el trabajo con el early adopter, se evaluará migrar esa VM a 4.6.0 **si existe un path de migración** — no se investigó en esta tarea. La VM nueva de este documento es independiente de esa migración futura; no la reemplaza ni depende de ella.
 
 ---
 
 ## 2. Cómo conecta la VM a lo que ya existe
 
 ```
-VM GCP nueva (e2-standard-2, solo WSO2 nativo)
+VM GCP nueva (e2-medium, solo WSO2 nativo)
   APIM 4.6.0 ──jdbc:postgresql──> PostgreSQL existente (registro/metadata interno: apim_db, shared_db)
   MI 4.x      ──(red interna del proyecto GCP, sin VPN/peering)──> Dnato existente
 ```
@@ -90,8 +96,8 @@ VM GCP nueva (e2-standard-2, solo WSO2 nativo)
 
 Pasos manuales — Claude Code no tiene acceso a la consola de GCP y no ejecuta nada de esto.
 
-1. **Confirmar región/VPC** donde ya viven Dnato y PostgreSQL en el proyecto GCP actual, y crear la VM nueva en esa misma región/red (evita latencia y cargos de tráfico inter-región).
-2. **Crear la VM**: tipo `e2-standard-2`, imagen Ubuntu 24.04 LTS (o la que ya se use para Dnato, por consistencia operativa), disco 30 GB pd-balanced.
+1. **Confirmar región/VPC** donde ya viven Dnato y PostgreSQL en el proyecto GCP actual, y crear la VM nueva en esa misma región/red (evita latencia y cargos de tráfico inter-región). Todo vive en el proyecto GCP "Trazalog" — para ver la zona exacta de cada VM existente: consola → Compute Engine → Instancias de VM (columna "Zona"), o con `gcloud compute instances list --project=<id-del-proyecto-trazalog> --format="table(name,zone,machineType,status)"` si tenés `gcloud` autenticado localmente.
+2. **Crear la VM**: tipo `e2-medium`, imagen Ubuntu 24.04 LTS (o la que ya se use para Dnato, por consistencia operativa), disco 20 GB pd-standard.
 3. **Reservar IP pública estática** y asociarla a la VM.
 4. **DNS**: apuntar `mcp.cloudtrazalog.com` (registro A) a la IP estática reservada en el paso 3.
 5. **Firewall del proyecto GCP**:
@@ -118,7 +124,7 @@ Pasos manuales — Claude Code no tiene acceso a la consola de GCP y no ejecuta 
 
 ## 5. Preguntas abiertas
 
-- **Costo real vs. ADR-005**: ver 1.4 — el sizing mínimo viable no es gratis. Requiere aprobación explícita de Rodolfo del gasto mensual (~US$50-60/mes incluyendo disco, a reconfirmar con el calculador oficial al momento de crear la VM).
-- **Región/VPC exacta** donde viven hoy Dnato y PostgreSQL — necesaria para decidir la región de la VM nueva (no investigable sin acceso a la consola de GCP de Rodolfo).
+- **Costo real vs. ADR-005**: ver 1.4 — `e2-medium` (~US$24-25/mes incluyendo disco, a reconfirmar con el calculador oficial) sigue sin ser $0, pero ya fue aceptado conscientemente por Rodolfo dado el volumen de 1-2 usuarios del piloto.
+- **Región/VPC exacta** donde viven hoy Dnato y PostgreSQL — ver el paso 1 del checklist (§4) para cómo consultarla en la consola o con `gcloud`.
 - **Versión exacta del MI**: se usa `4.5.0` por ser la validada junto al APIM 4.6.0 en DEV (ver `scripts/dev/setup-mi-b4-car-deploy.sh`). Si Rodolfo prefiere subir a una versión más nueva de MI, es una decisión aparte — no se investigó compatibilidad de versiones más nuevas contra el mecanismo de identidad de ADR-009.
 - **Migración de DataServices a PostgreSQL**: en curso pero no cerrada (`doc/identity/dataservices-remediation-phase-a.md`). Se detectó además que las datasources actuales (`AssetPlannerDataSource.xml`, `ToolsDataSource.xml`) tienen credenciales en texto plano commiteadas en el repo — preexistente, no introducido por esta tarea, pero vale la pena que Rodolfo lo sepa antes del cutover a producción.

--- a/doc/v3/deployment-gcp.md
+++ b/doc/v3/deployment-gcp.md
@@ -1,0 +1,124 @@
+# Despliegue en GCP — VM nativa WSO2 (ADR-011)
+
+> Implementa [ADR-011](../adr/ADR-011-gcp-deployment.md). Tarea: E7-INFRA-01/02.
+> Este documento NO despliega nada — es sizing + checklist para que Rodolfo
+> ejecute en su consola de GCP, más los scripts en [`deploy/gcp/`](../../deploy/gcp/).
+
+---
+
+## 1. Sizing de la VM
+
+### 1.1 Requisitos oficiales del stack (verificados contra doc oficial WSO2)
+
+| Componente | RAM mínima (oficial) | CPU mínima (oficial) | Fuente |
+|---|---|---|---|
+| WSO2 API Manager 4.6.0 (all-in-one) | **4 GB** (2 GB heap JVM + 2 GB SO) | 2 cores (3 GHz dual-core Xeon/Opteron o equiv.) | [Installation Prerequisites — APIM 4.6.0](https://apim.docs.wso2.com/en/4.6.0/install-and-setup/install/installation-prerequisites/) |
+| WSO2 Micro Integrator 4.x | Liviano — heap por defecto de fábrica `-Xms256m -Xmx1024m` en `bin/micro-integrator.sh` (footprint total ≈1 GB, reducido respecto a las ~4 GB de la generación EI anterior) | 1-2 cores compartidos | Confirmado en el script de arranque distribuido por WSO2; ver también `scripts/dev/setup-mi-b4-car-deploy.sh` de este repo (DEV corre MI 4.5.0 así) |
+
+**Conclusión:** correr APIM + MI + reverse proxy + SO en la misma VM necesita, como piso real, **RAM(APIM oficial) + RAM(MI liviano) + margen de SO/red** ≈ 4 GB + 1 GB + 1-2 GB ≈ **6-7 GB mínimo**, no los 4 GB que alcanzarían para el APIM solo.
+
+### 1.2 Comparación de tiers E2 (specs verificadas contra `docs.cloud.google.com`)
+
+| Tier | vCPU | RAM | Precio aprox.* (on-demand, us-central1) | ¿Aguanta el stack? |
+|---|---|---|---|---|
+| `e2-micro` | 2 vCPU compartidas (0.25 sustenido) | **1 GB** | Cubierto por Always Free (ver 1.3) | ❌ No. Por debajo del mínimo oficial del APIM solo (4 GB) |
+| `e2-small` | 2 vCPU compartidas (0.5 sustenido) | **2 GB** | ≈ US$12-15/mes | ❌ No. La mitad del mínimo oficial del APIM solo |
+| `e2-medium` | 2 vCPU compartidas (1.0 sustenido) | **4 GB** | ≈ US$24-25/mes | ⚠️ Al límite exacto del mínimo oficial del APIM **solo**, sin margen para el MI, el reverse proxy, sshd ni el SO. Riesgo real de OOM/lentitud — no recomendado para un despliegue de cara al cliente |
+| **`e2-standard-2`** | **2 vCPU dedicadas** | **8 GB** | ≈ US$48-52/mes | ✅ Sí. Cubre el mínimo oficial del APIM con margen, el MI en su heap liviano, y deja ~3-4 GB para SO/reverse proxy/monitoreo |
+
+\* Precios de referencia obtenidos de trackers de terceros (economize.cloud, cloudprice.net, vantage.sh) al momento de esta investigación (2026-07-21). **Cambian seguido y varían por región** — reconfirmar el número exacto en [cloud.google.com/products/calculator](https://cloud.google.com/products/calculator) antes de aprobar el gasto. No son los precios oficiales citados textualmente, son una referencia de orden de magnitud.
+
+### 1.3 Free tier — verificado contra la doc oficial
+
+Texto verbatim de la [documentación oficial Always Free](https://docs.cloud.google.com/free/docs/free-cloud-features) (consultada 2026-07-21):
+
+> "1 non-preemptible `e2-micro` VM instance per month in one of the following US regions: Oregon: `us-west1`. Iowa: `us-central1`. South Carolina: `us-east1`." + "30 GB-months standard persistent disk" + "1 GB of outbound data transfer from North America... per month."
+
+**El free tier solo cubre `e2-micro` (1 GB RAM)**, que según 1.1 es insuficiente incluso para el APIM solo (necesita 4 GB documentados por WSO2). `e2-small` y `e2-medium` **no están cubiertos** por Always Free bajo ninguna condición actual. No hay forma de correr este stack a costo $0 en Compute Engine nativo.
+
+### 1.4 Decisión de sizing
+
+**Tier elegido: `e2-standard-2` (2 vCPU, 8 GB RAM).**
+
+Justificación: es el primer tier que supera el mínimo oficial documentado por WSO2 para el APIM (4 GB) dejando margen real para el MI, el reverse proxy (Caddy) y el sistema operativo — `e2-medium` empata justo con el piso del APIM solo, sin ningún margen, lo cual es un riesgo inaceptable para el primer despliegue de cara a un cliente. El tipo de máquina es cambiable sin reinstalar (ADR-011, riesgo aceptado "sizing ajustado" — primer movimiento ante problemas de memoria es subir de tier).
+
+**⚠️ Punto que requiere confirmación explícita de Rodolfo antes de crear la VM:**
+ADR-005 establece costo incremental **$0 hasta 2027**. El sizing mínimo viable real (`e2-standard-2`) **no es gratuito** — ronda los US$48-52/mes (a reconfirmar con el calculador oficial). El free tier de Compute Engine no alcanza para este stack bajo ninguna combinación verificada. Esto es una excepción parcial a ADR-005 que el sizing técnico no puede evitar — se documenta acá para que sea una decisión consciente y no un descubrimiento post-facto en la factura de GCP.
+
+### 1.5 Reparto de heap propuesto (`e2-standard-2`, 8 GB total)
+
+| Proceso | `-Xms` | `-Xmx` | Nota |
+|---|---|---|---|
+| APIM | 2g | 3g | Prioridad de RAM (ADR-011 #4). Deja margen sobre el mínimo oficial de 2 GB heap |
+| MI | 256m | 768m | Cerca del default de fábrica (`256m`/`1024m`); se recorta el `-Xmx` levemente para dejarle más margen al APIM |
+| SO + Caddy + sshd + monitoreo | — | — | Resto (~3-4 GB) sin asignar a heap, disponible como colchón |
+
+Configurable en [`deploy/gcp/.env`](../../deploy/gcp/.env.example) (`APIM_XMS`/`APIM_XMX`/`MI_XMS`/`MI_XMX`) sin tener que reinstalar — volver a correr `install-apim.sh` / `install-mi.sh` reaplica la config sobre una instalación existente.
+
+### 1.6 Disco
+
+Ambos productos + logs necesitan holgadamente menos que los 10 GB mínimos que documenta WSO2 para el APIM solo. Se recomienda **30 GB pd-balanced** (o pd-standard si se prioriza costo sobre IOPS) — cubre APIM + MI + logs con margen para varios meses de crecimiento, a un costo marginal (unos pocos dólares/mes, verificar en el calculador).
+
+---
+
+## 2. Cómo conecta la VM a lo que ya existe
+
+```
+VM GCP nueva (e2-standard-2, solo WSO2 nativo)
+  APIM 4.6.0 ──jdbc:postgresql──> PostgreSQL existente (registro/metadata interno: apim_db, shared_db)
+  MI 4.x      ──(red interna del proyecto GCP, sin VPN/peering)──> Dnato existente
+```
+
+- **Red interna del proyecto GCP**: al estar la VM nueva, PostgreSQL y Dnato en el mismo proyecto, la conectividad es directa por IP interna — no requiere VPN ni peering (ADR-011 #6). Confirmar con Rodolfo el rango/subred donde viven Dnato y PostgreSQL hoy, para crear la VM nueva en la misma red (VPC) y, si aplica, la misma región (ver pregunta abierta en 4).
+- **Qué configuran los scripts**: `PG_HOST`/`PG_PORT`/credenciales en `deploy/gcp/.env` apuntan a la instancia PostgreSQL ya existente — `install-apim.sh` los usa para reescribir `[database.apim_db]` y `[database.shared_db]` en `deployment.toml` (registro/metadata **interno** del APIM, no las DataServices de negocio).
+- **Qué NO configuran los scripts**: las DataServices de negocio del MI (`AssetPlannerDataSource`, `ToolsDataSource`) están embebidas en el `.car` de `ToolsAPIProject` con su propia definición de conexión — hoy mezclan MySQL legacy y PostgreSQL (ver `doc/identity/dataservices-remediation-phase-a.md`, migración ya en curso pero no cerrada). Migrar esas conexiones es un cambio al proyecto Maven, no a la VM, y queda fuera de esta tarea.
+- **Identidad/JWT**: la config de `[apim.jwt]` + Key Manager federado de Dnato (ADR-008/ADR-009) tampoco la tocan estos scripts — es clase 🔴 (identidad/seguridad). Debe aplicarse como paso separado, replicando `doc/identity/apim-keymanager-dnato.md` contra el Dnato de este mismo proyecto GCP, antes de dar de alta al primer cliente.
+
+---
+
+## 3. Reverse proxy + TLS
+
+**Elegido: Caddy** (nativo, sin contenedor) por sobre nginx — Let's Encrypt automático con configuración mínima (un solo `Caddyfile` de ~15 líneas, sin certbot ni renovación manual), consistente con la prioridad de "cero curva de aprendizaje nueva" de ADR-011 #3.
+
+- Config: [`deploy/gcp/reverse-proxy/Caddyfile`](../../deploy/gcp/reverse-proxy/Caddyfile) — enruta `mcp.cloudtrazalog.com` (TLS Let's Encrypt) → `https://127.0.0.1:8243` (Gateway del APIM, certificado self-signed interno, válido porque el salto es loopback).
+- Instalación: [`deploy/gcp/setup-reverse-proxy.sh`](../../deploy/gcp/setup-reverse-proxy.sh) — repo oficial de Caddy (Cloudsmith), sin Docker.
+- **9443 (consola de administración) nunca se expone** — ni el Caddyfile ni las reglas de firewall de la sección 4 lo enrutan. Acceso a `/carbon`, `/publisher`, `/devportal` solo por túnel SSH o red interna (ADR-011 #9).
+
+---
+
+## 4. Checklist para Rodolfo (consola de GCP)
+
+Pasos manuales — Claude Code no tiene acceso a la consola de GCP y no ejecuta nada de esto.
+
+1. **Confirmar región/VPC** donde ya viven Dnato y PostgreSQL en el proyecto GCP actual, y crear la VM nueva en esa misma región/red (evita latencia y cargos de tráfico inter-región).
+2. **Crear la VM**: tipo `e2-standard-2`, imagen Ubuntu 24.04 LTS (o la que ya se use para Dnato, por consistencia operativa), disco 30 GB pd-balanced.
+3. **Reservar IP pública estática** y asociarla a la VM.
+4. **DNS**: apuntar `mcp.cloudtrazalog.com` (registro A) a la IP estática reservada en el paso 3.
+5. **Firewall del proyecto GCP**:
+   - Abrir **80/tcp** (requerido por el desafío HTTP-01 de Let's Encrypt) y **443/tcp** (tráfico público real), origen `0.0.0.0/0`.
+   - **NO** abrir 9443 al público — solo alcanzable desde la red interna del proyecto o vía túnel SSH (`gcloud compute ssh --tunnel-through-iap` o similar).
+   - Confirmar que el firewall interno permite que la VM llegue a PostgreSQL (5432) y a Dnato por su puerto correspondiente dentro de la misma VPC.
+6. **Orden de ejecución en la VM** (una vez creada y con acceso SSH):
+   ```bash
+   git clone <este repo> && cd traz-tools/deploy/gcp
+   cp .env.example .env   # completar con los valores reales
+   # descargar manualmente wso2am-4.6.0.zip y wso2mi-4.5.0.zip desde wso2.com
+   # (cuenta gratuita) y el driver JDBC de PostgreSQL desde jdbc.postgresql.org,
+   # dejarlos en las rutas indicadas en .env
+   sudo ./install-apim.sh
+   sudo ./install-mi.sh
+   sudo ./setup-reverse-proxy.sh
+   sudo systemctl start wso2am
+   sudo systemctl start wso2mi
+   ```
+7. **Smoke test** (equivalente al de DEV en `doc/infra/wso2-install.md` §5): `curl -I https://mcp.cloudtrazalog.com` debe responder con el cert de Let's Encrypt (no self-signed), y proxyear al Gateway del APIM.
+8. **Antes de dar de alta al primer cliente**: aplicar la config de identidad (ADR-008/009) y cerrar la migración de DataServices a PostgreSQL — ninguna de las dos está cubierta por esta tarea.
+
+---
+
+## 5. Preguntas abiertas
+
+- **Costo real vs. ADR-005**: ver 1.4 — el sizing mínimo viable no es gratis. Requiere aprobación explícita de Rodolfo del gasto mensual (~US$50-60/mes incluyendo disco, a reconfirmar con el calculador oficial al momento de crear la VM).
+- **Región/VPC exacta** donde viven hoy Dnato y PostgreSQL — necesaria para decidir la región de la VM nueva (no investigable sin acceso a la consola de GCP de Rodolfo).
+- **Versión exacta del MI**: se usa `4.5.0` por ser la validada junto al APIM 4.6.0 en DEV (ver `scripts/dev/setup-mi-b4-car-deploy.sh`). Si Rodolfo prefiere subir a una versión más nueva de MI, es una decisión aparte — no se investigó compatibilidad de versiones más nuevas contra el mecanismo de identidad de ADR-009.
+- **Migración de DataServices a PostgreSQL**: en curso pero no cerrada (`doc/identity/dataservices-remediation-phase-a.md`). Se detectó además que las datasources actuales (`AssetPlannerDataSource.xml`, `ToolsDataSource.xml`) tienen credenciales en texto plano commiteadas en el repo — preexistente, no introducido por esta tarea, pero vale la pena que Rodolfo lo sepa antes del cutover a producción.

--- a/doc/v3/deployment-gcp.md
+++ b/doc/v3/deployment-gcp.md
@@ -75,7 +75,7 @@ VM GCP nueva (e2-medium, solo WSO2 nativo)
   MI 4.x      ──(red interna del proyecto GCP, sin VPN/peering)──> Dnato existente
 ```
 
-- **Red interna del proyecto GCP**: al estar la VM nueva, PostgreSQL y Dnato en el mismo proyecto, la conectividad es directa por IP interna — no requiere VPN ni peering (ADR-011 #6). Confirmar con Rodolfo el rango/subred donde viven Dnato y PostgreSQL hoy, para crear la VM nueva en la misma red (VPC) y, si aplica, la misma región (ver pregunta abierta en 4).
+- **Red interna del proyecto GCP**: al estar la VM nueva, PostgreSQL y Dnato en el mismo proyecto, la conectividad es directa por IP interna — no requiere VPN ni peering (ADR-011 #6). **Zona confirmada por Rodolfo: `us-east1-b`** — la VM nueva se crea ahí, misma zona que el resto del stack existente (Dnato, PostgreSQL, y la VM legacy con WSO2 4.4).
 - **Qué configuran los scripts**: `PG_HOST`/`PG_PORT`/credenciales en `deploy/gcp/.env` apuntan a la instancia PostgreSQL ya existente — `install-apim.sh` los usa para reescribir `[database.apim_db]` y `[database.shared_db]` en `deployment.toml` (registro/metadata **interno** del APIM, no las DataServices de negocio).
 - **Qué NO configuran los scripts**: las DataServices de negocio del MI (`AssetPlannerDataSource`, `ToolsDataSource`) están embebidas en el `.car` de `ToolsAPIProject` con su propia definición de conexión — hoy mezclan MySQL legacy y PostgreSQL (ver `doc/identity/dataservices-remediation-phase-a.md`, migración ya en curso pero no cerrada). Migrar esas conexiones es un cambio al proyecto Maven, no a la VM, y queda fuera de esta tarea.
 - **Identidad/JWT**: la config de `[apim.jwt]` + Key Manager federado de Dnato (ADR-008/ADR-009) tampoco la tocan estos scripts — es clase 🔴 (identidad/seguridad). Debe aplicarse como paso separado, replicando `doc/identity/apim-keymanager-dnato.md` contra el Dnato de este mismo proyecto GCP, antes de dar de alta al primer cliente.
@@ -96,8 +96,8 @@ VM GCP nueva (e2-medium, solo WSO2 nativo)
 
 Pasos manuales — Claude Code no tiene acceso a la consola de GCP y no ejecuta nada de esto.
 
-1. **Confirmar región/VPC** donde ya viven Dnato y PostgreSQL en el proyecto GCP actual, y crear la VM nueva en esa misma región/red (evita latencia y cargos de tráfico inter-región). Todo vive en el proyecto GCP "Trazalog" — para ver la zona exacta de cada VM existente: consola → Compute Engine → Instancias de VM (columna "Zona"), o con `gcloud compute instances list --project=<id-del-proyecto-trazalog> --format="table(name,zone,machineType,status)"` si tenés `gcloud` autenticado localmente.
-2. **Crear la VM**: tipo `e2-medium`, imagen Ubuntu 24.04 LTS (o la que ya se use para Dnato, por consistencia operativa), disco 20 GB pd-standard.
+1. ~~Confirmar región/VPC~~ **Confirmado: `us-east1-b`** (proyecto GCP "Trazalog") — misma zona donde ya viven Dnato, PostgreSQL y la VM legacy con WSO2 4.4. Crear la VM nueva ahí (evita latencia y cargos de tráfico inter-región/inter-zona).
+2. **Crear la VM**: tipo `e2-medium`, zona `us-east1-b`, imagen Ubuntu 24.04 LTS (o la que ya se use para Dnato, por consistencia operativa), disco 20 GB pd-standard.
 3. **Reservar IP pública estática** y asociarla a la VM.
 4. **DNS**: apuntar `mcp.cloudtrazalog.com` (registro A) a la IP estática reservada en el paso 3.
 5. **Firewall del proyecto GCP**:
@@ -125,6 +125,6 @@ Pasos manuales — Claude Code no tiene acceso a la consola de GCP y no ejecuta 
 ## 5. Preguntas abiertas
 
 - **Costo real vs. ADR-005**: ver 1.4 — `e2-medium` (~US$24-25/mes incluyendo disco, a reconfirmar con el calculador oficial) sigue sin ser $0, pero ya fue aceptado conscientemente por Rodolfo dado el volumen de 1-2 usuarios del piloto.
-- **Región/VPC exacta** donde viven hoy Dnato y PostgreSQL — ver el paso 1 del checklist (§4) para cómo consultarla en la consola o con `gcloud`.
+- ~~Región/VPC exacta~~ **Resuelto: `us-east1-b`** (ver §2 y §4 paso 1).
 - **Versión exacta del MI**: se usa `4.5.0` por ser la validada junto al APIM 4.6.0 en DEV (ver `scripts/dev/setup-mi-b4-car-deploy.sh`). Si Rodolfo prefiere subir a una versión más nueva de MI, es una decisión aparte — no se investigó compatibilidad de versiones más nuevas contra el mecanismo de identidad de ADR-009.
 - **Migración de DataServices a PostgreSQL**: en curso pero no cerrada (`doc/identity/dataservices-remediation-phase-a.md`). Se detectó además que las datasources actuales (`AssetPlannerDataSource.xml`, `ToolsDataSource.xml`) tienen credenciales en texto plano commiteadas en el repo — preexistente, no introducido por esta tarea, pero vale la pena que Rodolfo lo sepa antes del cutover a producción.

--- a/doc/v3/deployment-gcp.md
+++ b/doc/v3/deployment-gcp.md
@@ -94,61 +94,69 @@ VM GCP nueva (e2-medium, solo WSO2 nativo)
 
 ---
 
-## 4. Checklist para Rodolfo (consola de GCP)
+## 4. Checklist para Rodolfo (ejecución manual)
 
 Pasos manuales — Claude Code no tiene acceso a la consola de GCP y no ejecuta nada de esto.
 
-> **Cómo correr los comandos `gcloud` de este checklist sin instalar nada:** los pasos 3 y 5 usan `gcloud`. No hace falta instalarlo en ninguna máquina — se usa **Cloud Shell**, la terminal integrada en el navegador de la consola de GCP:
-> 1. Ir a [console.cloud.google.com](https://console.cloud.google.com) y loguearse con la cuenta de Trazalog.
-> 2. Arriba a la izquierda, click en el selector de proyecto → buscar **"Trazalog"** → seleccionarlo. Confirmar que la barra superior queda con ese proyecto activo.
-> 3. Arriba a la derecha, click en el ícono de terminal (`>_`, "Activate Cloud Shell"). Esperar a que inicialice.
-> 4. Verificar el proyecto activo: `gcloud config get-value project` (debe mostrar el ID del proyecto Trazalog).
-> 5. Pegar ahí los comandos `gcloud compute...` de los pasos 3 y 5, uno por vez.
->
-> Estos comandos son de **configuración del proyecto** (IP, firewall) — se corren desde Cloud Shell, **no por SSH dentro de la VM nueva**. El acceso por SSH a la VM recién aparece en los pasos 6-7 (instalar JDK, correr los scripts de `deploy/gcp/`).
+**Este checklist se ejecuta en 3 lugares distintos. Cada paso dice cuál con una etiqueta:**
 
-1. ~~Confirmar región/VPC~~ **Confirmado: `us-east1-b`** (proyecto GCP "Trazalog") — misma zona donde ya viven Dnato, PostgreSQL y la VM legacy con WSO2 4.4. Crear la VM nueva ahí (evita latencia y cargos de tráfico inter-región/inter-zona).
-2. **Crear la VM**: tipo `e2-medium`, zona `us-east1-b`, imagen **Rocky Linux 9** (decisión ya tomada en IDR-001, ver 1.1 — no Ubuntu ni CentOS 7), disco 20 GB pd-standard.
-   - **Ojo con la variante de imagen**: en el selector de GCP puede aparecer "Rocky Linux 10 optimized for GCP with out-of-tree GVNIC (GVE) Support". **No usar la 10** — la [matriz oficial de compatibilidad de WSO2 4.6.0](https://apim.docs.wso2.com/en/4.6.0/install-and-setup/setup/reference/product-compatibility/) lista `Rocky Linux 8.7`/`9.3` como testeados; Rocky 10/RHEL 10 no figura ahí. GVNIC solo aporta en tráfico intensivo o familias de máquina específicas (C3, N2D, Tau T2D) — irrelevante para un `e2-medium` de 1-2 usuarios. Si existe una variante "Rocky Linux 9 optimized for GCP" (con o sin GVNIC), esa sí sirve igual.
-3. **Reservar IP pública estática** y asociarla a la VM.
+| Etiqueta | Qué es | Cuándo se usa |
+|---|---|---|
+| 🖥️ **Consola web** | `console.cloud.google.com`, clicks con el mouse | Crear la VM, ver/reservar IP, ver reglas de firewall (opcional, alternativa a los comandos) |
+| ⌨️ **Cloud Shell** | Terminal integrada en la consola web (botón `>_` arriba a la derecha). No requiere instalar nada — ya viene logueada y con `gcloud` listo | Todos los comandos `gcloud` de este checklist (pasos 3 y 5) |
+| 💻 **SSH en la VM** | Terminal conectada DENTRO de la VM nueva ya creada | Instalar JDK y correr los scripts de `deploy/gcp/` (pasos 6 y 7) |
 
-   Al crear la VM (paso 2), GCP le asigna una IP pública **efímera** (cambia si se reinicia). Hay que promoverla a estática para que `mcp.cloudtrazalog.com` no se rompa en cada reinicio.
+### 4.0 Antes de empezar: abrir Cloud Shell (una sola vez)
 
-   Con `gcloud` (desde la máquina local, proyecto "Trazalog" seleccionado):
-   ```bash
-   # ver la IP efímera actual de la VM
-   gcloud compute instances describe NOMBRE_VM --zone=us-east1-b \
-     --format="get(networkInterfaces[0].accessConfigs[0].natIP)"
+1. 🖥️ Ir a [console.cloud.google.com](https://console.cloud.google.com) y loguearse con la cuenta de Trazalog.
+2. 🖥️ Arriba a la izquierda, click en el selector de proyecto → buscar **"Trazalog"** → seleccionarlo. Confirmar que la barra superior queda con ese proyecto activo.
+3. 🖥️ Arriba a la derecha, click en el ícono de terminal (`>_`, tooltip "Activate Cloud Shell"). Se abre una terminal abajo de la pantalla — esperar a que inicialice.
+4. ⌨️ Confirmar el proyecto activo: `gcloud config get-value project` → tiene que mostrar el ID del proyecto Trazalog.
 
-   # promoverla a estática (usar la IP que devolvió el comando anterior)
-   gcloud compute addresses create mcp-cloudtrazalog-ip \
-     --region=us-east1 \
-     --addresses=LA_IP_DEL_COMANDO_ANTERIOR
-   ```
-   Por consola: `VPC network` → `IP addresses` → la IP de la VM aparece como "In use" / "Ephemeral" → botón **"Reserve Static Address"** en esa fila. Queda asociada a la misma VM sin tocar nada más.
+Cloud Shell queda disponible para todo el resto del checklist — no hay que repetir esto en cada paso.
 
-4. **DNS**: apuntar `mcp.cloudtrazalog.com` (registro A) a la IP estática reservada en el paso 3.
+### 4.1 Pasos
 
-   Se hace en el panel de quien administra hoy el DNS de `cloudtrazalog.com` (fuera de GCP, salvo que ese dominio use Cloud DNS) — probablemente el mismo lugar donde está configurado el DNS de v2.
-   - Tipo: **A**
-   - Nombre/Host: **mcp** (o `mcp.cloudtrazalog.com` completo, según el proveedor)
-   - Valor: la IP estática del paso 3
-   - TTL: default del proveedor
+1. ~~Confirmar región/VPC~~ ✅ **Confirmado: `us-east1-b`** (proyecto GCP "Trazalog") — misma zona donde ya viven Dnato, PostgreSQL y la VM legacy con WSO2 4.4. Crear la VM nueva ahí.
 
-   Verificar propagación (puede tardar de minutos a un par de horas):
-   ```bash
-   dig +short mcp.cloudtrazalog.com
-   # o: nslookup mcp.cloudtrazalog.com
-   ```
-   Tiene que devolver la IP estática reservada.
+2. 🖥️ **Consola web — crear la VM**: `Compute Engine` → `VM instances` → `Create instance`.
+   - Tipo de máquina: `e2-medium`
+   - Zona: `us-east1-b`
+   - Imagen del sistema operativo: **Rocky Linux 9** — decisión ya tomada en IDR-001 (ver §1.1), no Ubuntu ni CentOS 7.
+     - ⚠️ En el selector puede aparecer también "Rocky Linux 10 optimized for GCP with GVNIC". **No elegir la 10** — la [matriz oficial de WSO2 4.6.0](https://apim.docs.wso2.com/en/4.6.0/install-and-setup/setup/reference/product-compatibility/) solo lista Rocky Linux `8.7`/`9.3` como testeados, la 10 no figura. GVNIC no aporta nada relevante para este tamaño de VM.
+   - Disco: 20 GB, tipo `pd-standard`.
 
-5. **Firewall del proyecto GCP**:
-   - **Usar una etiqueta de red (tag), no "todas las instancias"** — el proyecto ya tiene otras VMs corriendo (Dnato, PostgreSQL, la VM legacy WSO2 4.4); una regla sin scope les abriría 80/443 también a ellas.
+3. **Reservar IP pública estática** (para que `mcp.cloudtrazalog.com` no se rompa si la VM se reinicia).
+   - ⌨️ **Cloud Shell**:
      ```bash
-     # etiquetar la VM nueva (si no se hizo al crearla)
+     # 1. ver la IP efímera que GCP le asignó a la VM en el paso 2
+     gcloud compute instances describe NOMBRE_VM --zone=us-east1-b \
+       --format="get(networkInterfaces[0].accessConfigs[0].natIP)"
+
+     # 2. promoverla a estática (usar la IP que devolvió el comando anterior)
+     gcloud compute addresses create mcp-cloudtrazalog-ip \
+       --region=us-east1 \
+       --addresses=LA_IP_DEL_COMANDO_ANTERIOR
+     ```
+   - Alternativa 🖥️ **consola web**: `VPC network` → `IP addresses` → la IP de la VM aparece como "In use"/"Ephemeral" → botón **"Reserve Static Address"** en esa fila.
+
+4. **DNS**: apuntar `mcp.cloudtrazalog.com` (registro A) a la IP estática del paso 3.
+   - 🌐 **Panel del proveedor de DNS de `cloudtrazalog.com`** (fuera de GCP — el mismo lugar donde está configurado hoy el DNS de v2):
+     - Tipo: `A`
+     - Nombre/Host: `mcp`
+     - Valor: la IP estática del paso 3
+     - TTL: default del proveedor
+   - ⌨️ **Cloud Shell** (o cualquier terminal), para verificar que propagó (puede tardar de minutos a un par de horas):
+     ```bash
+     dig +short mcp.cloudtrazalog.com
+     ```
+     Tiene que devolver la IP estática reservada.
+
+5. **Firewall del proyecto GCP** — todo en ⌨️ **Cloud Shell**:
+   - **Etiquetar la VM y abrir 80/443 solo para ella** (no "todas las instancias" — el proyecto ya tiene otras VMs como Dnato y la VM legacy 4.4, y no queremos abrirles estos puertos también):
+     ```bash
      gcloud compute instances add-tags NOMBRE_VM --zone=us-east1-b --tags=mcp-gateway
 
-     # regla de firewall, solo para instancias con esa etiqueta
      gcloud compute firewall-rules create allow-mcp-http-https \
        --network=default \
        --direction=INGRESS \
@@ -157,22 +165,20 @@ Pasos manuales — Claude Code no tiene acceso a la consola de GCP y no ejecuta 
        --source-ranges=0.0.0.0/0 \
        --target-tags=mcp-gateway
      ```
-     (si la red no se llama `default`, chequear con `gcloud compute networks list` y ajustar `--network`)
-   - **NO** crear ninguna regla que abra 9443 al público. GCP deniega todo ingreso por defecto salvo que exista una regla `ALLOW` explícita — mientras no se cree una, ya está cerrado. Confirmar que no exista ya una regla vieja demasiado permisiva:
+     (si la red del proyecto no se llama `default`, chequear con `gcloud compute networks list` y ajustar `--network`)
+   - **NO crear ninguna regla que abra 9443 al público.** GCP deniega todo por defecto salvo regla `ALLOW` explícita — no crear ninguna alcanza. Confirmar que no exista ya una regla vieja demasiado abierta:
      ```bash
      gcloud compute firewall-rules list --format="table(name,sourceRanges.list(),allowed[].map().firewall_rule().list(),targetTags.list())"
      ```
-     Si aparece algo con `0.0.0.0/0` y rango de puertos amplio (`0-65535` o similar), no tocarlo sin confirmar antes qué lo usa.
-   - **Conectividad interna a PostgreSQL/Dnato**: PostgreSQL corre en una VM propia (`traz-db-prod`, no es Cloud SQL administrado — ver `TRAZALOG_v3_MCP_ARCHITECTURE.md` §10.5), así que la conectividad depende de compartir la misma red VPC, no de reglas de firewall nuevas. Si el proyecto usa la red `default`, ya existe la regla `default-allow-internal` que permite todo el tráfico interno entre VMs del proyecto — solo hace falta confirmar que la VM nueva quedó en esa misma red:
+     Si aparece algo con `0.0.0.0/0` y un rango de puertos amplio (`0-65535` o similar), avisar antes de tocar nada.
+   - **Confirmar que la VM llega a PostgreSQL/Dnato por red interna** (PostgreSQL corre en su propia VM, `traz-db-prod`, no es Cloud SQL administrado — ver `TRAZALOG_v3_MCP_ARCHITECTURE.md` §10.5). Si todas están en la red `default`, ya existe la regla `default-allow-internal` que permite el tráfico interno entre VMs del proyecto — solo falta confirmar que quedaron en la misma red:
      ```bash
-     gcloud compute instances describe NOMBRE_VM --zone=us-east1-b \
-       --format="get(networkInterfaces[0].network)"
-     gcloud compute instances describe NOMBRE_VM_POSTGRES --zone=us-east1-b \
-       --format="get(networkInterfaces[0].network)"
+     gcloud compute instances describe NOMBRE_VM --zone=us-east1-b --format="get(networkInterfaces[0].network)"
+     gcloud compute instances describe NOMBRE_VM_POSTGRES --zone=us-east1-b --format="get(networkInterfaces[0].network)"
      ```
-     Si ambos comandos devuelven la misma red, está cubierto. Si difieren, hace falta peering o una regla específica — no asumir, chequear antes de seguir.
-   - **`firewalld` dentro de la VM**: la [doc oficial de GCP](https://docs.cloud.google.com/compute/docs/images/os-details) confirma para AlmaLinux/CentOS que "por defecto se permite todo el tráfico a través del firewall del guest, porque las reglas de firewall de la VPC lo overridean" — la sección de Rocky Linux específicamente no está en esa página, pero es la misma familia de imagen RHEL-like, así que es razonable esperar el mismo comportamiento. **No verificado 1:1 para Rocky** — al llegar a este paso, correr `sudo firewall-cmd --state` y, si está `running`, confirmar con `sudo firewall-cmd --list-all` que 80/443 pasan (o agregarlos con `firewall-cmd --add-port=80/tcp --add-port=443/tcp --permanent && firewall-cmd --reload`) antes de asumir que alcanza con la regla de la VPC.
-6. **Instalar JDK 21 Temurin** (requisito de WSO2 4.6.0 — verificado contra [adoptium.net/installation/linux](https://adoptium.net/installation/linux/), repo RPM oficial con soporte explícito para Rocky Linux):
+     Mismo resultado en ambos → OK. Distinto → parar y avisar (haría falta peering o una regla nueva).
+
+6. 💻 **SSH en la VM — instalar JDK 21 Temurin** (requisito de WSO2 4.6.0). Primero conectarse: 🖥️ `Compute Engine` → `VM instances` → botón **"SSH"** al lado de la VM nueva (abre una terminal en el navegador, sin configurar claves). Una vez adentro:
    ```bash
    sudo tee /etc/yum.repos.d/adoptium.repo <<'EOF'
    [Adoptium]
@@ -185,8 +191,9 @@ Pasos manuales — Claude Code no tiene acceso a la consola de GCP y no ejecuta 
    sudo dnf install -y temurin-21-jdk
    java -version   # debe mostrar "21.x.x"
    ```
-   `install-apim.sh`/`install-mi.sh` detectan `JAVA_HOME` automáticamente a partir del `java` instalado (o respetan `$JAVA_HOME` si ya está seteado) y lo escriben en el unit de systemd — a diferencia de DEV (`doc/infra/wso2-install.md`), acá no alcanza con `/etc/profile.d`, porque systemd no lo lee.
-7. **Orden de ejecución en la VM** (una vez creada y con acceso SSH):
+   Fuente: [adoptium.net/installation/linux](https://adoptium.net/installation/linux/) (repo RPM oficial, con soporte explícito para Rocky Linux). `install-apim.sh`/`install-mi.sh` (paso 7) detectan `JAVA_HOME` solos a partir de este `java` instalado y lo escriben en el unit de systemd — a diferencia de DEV (`doc/infra/wso2-install.md`), acá no alcanza con `/etc/profile.d` porque systemd no lo lee.
+
+7. 💻 **SSH en la VM (misma sesión que el paso 6) — instalar y arrancar WSO2**:
    ```bash
    git clone <este repo> && cd traz-tools/deploy/gcp
    cp .env.example .env   # completar con los valores reales
@@ -199,8 +206,25 @@ Pasos manuales — Claude Code no tiene acceso a la consola de GCP y no ejecuta 
    sudo systemctl start wso2am
    sudo systemctl start wso2mi
    ```
-8. **Smoke test** (equivalente al de DEV en `doc/infra/wso2-install.md` §5): `curl -I https://mcp.cloudtrazalog.com` debe responder con el cert de Let's Encrypt (no self-signed), y proxyear al Gateway del APIM.
-9. **Antes de dar de alta al primer cliente**: aplicar la config de identidad (ADR-008/009) y cerrar la migración de DataServices a PostgreSQL — ninguna de las dos está cubierta por esta tarea.
+   Nota sobre `setup-reverse-proxy.sh`: instala Caddy vía `dnf`/Copr siguiendo la sección "CentOS/RHEL" de [caddyserver.com/docs/install](https://caddyserver.com/docs/install) — esa página no nombra Rocky Linux explícitamente (Rocky es rebuild 1:1 de RHEL, debería resolver igual, pero no está confirmado 1:1). Verificar `caddy version` en el smoke test (paso 8).
+
+   También en esta sesión SSH, chequear `firewalld` (no confirmado 1:1 para Rocky en la doc oficial de GCP — ver nota abajo):
+   ```bash
+   sudo firewall-cmd --state
+   # si dice "running":
+   sudo firewall-cmd --list-all
+   # si 80/443 no aparecen:
+   sudo firewall-cmd --add-port=80/tcp --add-port=443/tcp --permanent && sudo firewall-cmd --reload
+   ```
+   *(La [doc oficial de GCP](https://docs.cloud.google.com/compute/docs/images/os-details) confirma para AlmaLinux/CentOS que el firewall del guest permite todo por defecto porque las reglas de la VPC lo overridean — Rocky no está listada ahí explícitamente, pero es la misma familia de imagen. Por eso este chequeo, en vez de asumirlo.)*
+
+8. ⌨️ **Cloud Shell (o cualquier terminal, incluso tu compu) — smoke test** (equivalente al de DEV en `doc/infra/wso2-install.md` §5):
+   ```bash
+   curl -I https://mcp.cloudtrazalog.com
+   ```
+   Tiene que responder con el certificado de Let's Encrypt (no self-signed) y proxyear al Gateway del APIM.
+
+9. **Antes de dar de alta al primer cliente** (no es parte de esta tarea, queda pendiente aparte): aplicar la config de identidad (ADR-008/009) y cerrar la migración de DataServices a PostgreSQL.
 
 ---
 

--- a/doc/v3/deployment-gcp.md
+++ b/doc/v3/deployment-gcp.md
@@ -17,6 +17,8 @@
 
 **Estos son los mínimos "de catálogo" de WSO2**, pensados para un ambiente de producción genérico con carga concurrente real. No son el punto de partida correcto para dimensionar el piloto: Rodolfo ya corre APIM+MI en su máquina de desarrollo con heaps de fábrica (`MI: -Xms256m -Xmx1024m`, sin tocar nada) y le anda bien. El early adopter va a tener **1-2 usuarios**, no la carga concurrente que esos mínimos oficiales asumen. Se prioriza ese dato empírico + el volumen real esperado por sobre el catálogo oficial (ver decisión en 1.4).
 
+**Sistema operativo: `Rocky Linux 9`** — ya decidido en la arquitectura canónica (`TRAZALOG_v3_MCP_ARCHITECTURE.md` §9-10, decisión **IDR-001**), no es una elección nueva de esta tarea. Ese documento estableció que WSO2 4.6.0 requiere JDK 21, y CentOS 7 (el SO histórico de Trazalog) quedó EOL en junio 2024 con una `glibc` (2.17) incompatible con los builds modernos de JDK 21 — por eso IDR-001 fija Rocky Linux 9 (drop-in replacement de CentOS/RHEL, soporte hasta 2032) como el SO de cualquier VM nueva de WSO2 en v3. Ubuntu fue evaluada en ese mismo documento y descartada salvo "razón estratégica" (cambio de paradigma apt↔dnf sin beneficio para este caso). La primera versión de este documento decía Ubuntu 24.04 LTS por error — se tomó como referencia el SO del workstation de DEV de Rodolfo (`doc/infra/wso2-install.md`) en vez de la decisión ya tomada en la arquitectura canónica. Corregido acá.
+
 ### 1.2 Comparación de tiers E2 (specs verificadas contra `docs.cloud.google.com`)
 
 | Tier | vCPU | RAM | Precio aprox.* (on-demand, us-central1) | ¿Aguanta 1-2 usuarios piloto? |
@@ -87,7 +89,7 @@ VM GCP nueva (e2-medium, solo WSO2 nativo)
 **Elegido: Caddy** (nativo, sin contenedor) por sobre nginx — Let's Encrypt automático con configuración mínima (un solo `Caddyfile` de ~15 líneas, sin certbot ni renovación manual), consistente con la prioridad de "cero curva de aprendizaje nueva" de ADR-011 #3.
 
 - Config: [`deploy/gcp/reverse-proxy/Caddyfile`](../../deploy/gcp/reverse-proxy/Caddyfile) — enruta `mcp.cloudtrazalog.com` (TLS Let's Encrypt) → `https://127.0.0.1:8243` (Gateway del APIM, certificado self-signed interno, válido porque el salto es loopback).
-- Instalación: [`deploy/gcp/setup-reverse-proxy.sh`](../../deploy/gcp/setup-reverse-proxy.sh) — repo oficial de Caddy (Cloudsmith), sin Docker.
+- Instalación: [`deploy/gcp/setup-reverse-proxy.sh`](../../deploy/gcp/setup-reverse-proxy.sh) — repo oficial de Caddy vía `dnf`/Copr (paquete `caddy` para Fedora/RHEL/Rocky), sin Docker.
 - **9443 (consola de administración) nunca se expone** — ni el Caddyfile ni las reglas de firewall de la sección 4 lo enrutan. Acceso a `/carbon`, `/publisher`, `/devportal` solo por túnel SSH o red interna (ADR-011 #9).
 
 ---
@@ -97,7 +99,7 @@ VM GCP nueva (e2-medium, solo WSO2 nativo)
 Pasos manuales — Claude Code no tiene acceso a la consola de GCP y no ejecuta nada de esto.
 
 1. ~~Confirmar región/VPC~~ **Confirmado: `us-east1-b`** (proyecto GCP "Trazalog") — misma zona donde ya viven Dnato, PostgreSQL y la VM legacy con WSO2 4.4. Crear la VM nueva ahí (evita latencia y cargos de tráfico inter-región/inter-zona).
-2. **Crear la VM**: tipo `e2-medium`, zona `us-east1-b`, imagen Ubuntu 24.04 LTS (o la que ya se use para Dnato, por consistencia operativa), disco 20 GB pd-standard.
+2. **Crear la VM**: tipo `e2-medium`, zona `us-east1-b`, imagen **Rocky Linux 9** (decisión ya tomada en IDR-001, ver 1.1 — no Ubuntu ni CentOS 7), disco 20 GB pd-standard.
 3. **Reservar IP pública estática** y asociarla a la VM.
 4. **DNS**: apuntar `mcp.cloudtrazalog.com` (registro A) a la IP estática reservada en el paso 3.
 5. **Firewall del proyecto GCP**:

--- a/doc/v3/deployment-gcp.md
+++ b/doc/v3/deployment-gcp.md
@@ -183,7 +183,7 @@ Cloud Shell queda disponible para todo el resto del checklist — no hay que rep
    sudo tee /etc/yum.repos.d/adoptium.repo <<'EOF'
    [Adoptium]
    name=Adoptium
-   baseurl=https://packages.adoptium.net/artifactory/rpm/rocky/$releasever/$basearch
+   baseurl=https://packages.adoptium.net/artifactory/rpm/rhel/$releasever/$basearch
    enabled=1
    gpgcheck=1
    gpgkey=https://packages.adoptium.net/artifactory/api/gpg/key/public
@@ -191,7 +191,7 @@ Cloud Shell queda disponible para todo el resto del checklist — no hay que rep
    sudo dnf install -y temurin-21-jdk
    java -version   # debe mostrar "21.x.x"
    ```
-   Fuente: [adoptium.net/installation/linux](https://adoptium.net/installation/linux/) (repo RPM oficial, con soporte explícito para Rocky Linux). `install-apim.sh`/`install-mi.sh` (paso 7) detectan `JAVA_HOME` solos a partir de este `java` instalado y lo escriben en el unit de systemd — a diferencia de DEV (`doc/infra/wso2-install.md`), acá no alcanza con `/etc/profile.d` porque systemd no lo lee.
+   Fuente: [adoptium.net/installation/linux](https://adoptium.net/installation/linux/), repo RPM oficial de Adoptium. **Usar `rhel` en el `baseurl`, no `rocky`** — el path `rpm/rocky/` de Adoptium solo tiene paquetes para Rocky Linux 8 (`rpm/rocky/8/`), no existe `rpm/rocky/9/` (probado en la práctica: da 404). `rpm/rhel/9/x86_64/` sí existe y aplica igual a Rocky 9 por ser compatible 1:1 con RHEL 9. `install-apim.sh`/`install-mi.sh` (paso 7) detectan `JAVA_HOME` solos a partir de este `java` instalado y lo escriben en el unit de systemd — a diferencia de DEV (`doc/infra/wso2-install.md`), acá no alcanza con `/etc/profile.d` porque systemd no lo lee.
 
 7. 💻 **SSH en la VM (misma sesión que el paso 6) — instalar y arrancar WSO2**:
    ```bash

--- a/doc/v3/deployment-gcp.md
+++ b/doc/v3/deployment-gcp.md
@@ -89,7 +89,7 @@ VM GCP nueva (e2-medium, solo WSO2 nativo)
 **Elegido: Caddy** (nativo, sin contenedor) por sobre nginx — Let's Encrypt automático con configuración mínima (un solo `Caddyfile` de ~15 líneas, sin certbot ni renovación manual), consistente con la prioridad de "cero curva de aprendizaje nueva" de ADR-011 #3.
 
 - Config: [`deploy/gcp/reverse-proxy/Caddyfile`](../../deploy/gcp/reverse-proxy/Caddyfile) — enruta `mcp.cloudtrazalog.com` (TLS Let's Encrypt) → `https://127.0.0.1:8243` (Gateway del APIM, certificado self-signed interno, válido porque el salto es loopback).
-- Instalación: [`deploy/gcp/setup-reverse-proxy.sh`](../../deploy/gcp/setup-reverse-proxy.sh) — repo oficial de Caddy vía `dnf`/Copr (paquete `caddy` para Fedora/RHEL/Rocky), sin Docker.
+- Instalación: [`deploy/gcp/setup-reverse-proxy.sh`](../../deploy/gcp/setup-reverse-proxy.sh) — repo oficial de Caddy vía `dnf`/Copr, siguiendo al pie de la letra la sección "CentOS/RHEL" de [caddyserver.com/docs/install](https://caddyserver.com/docs/install) (`dnf-plugins-core` + `dnf copr enable @caddy/caddy`). Esa página no nombra Rocky Linux explícitamente (solo Fedora/RedHat/CentOS) — Rocky es rebuild 1:1 de RHEL así que debería resolver igual, pero no está confirmado 1:1 en la doc oficial de Caddy. Verificar `caddy version` después de correr el script como parte del smoke test (paso 8).
 - **9443 (consola de administración) nunca se expone** — ni el Caddyfile ni las reglas de firewall de la sección 4 lo enrutan. Acceso a `/carbon`, `/publisher`, `/devportal` solo por túnel SSH o red interna (ADR-011 #9).
 
 ---
@@ -106,7 +106,22 @@ Pasos manuales — Claude Code no tiene acceso a la consola de GCP y no ejecuta 
    - Abrir **80/tcp** (requerido por el desafío HTTP-01 de Let's Encrypt) y **443/tcp** (tráfico público real), origen `0.0.0.0/0`.
    - **NO** abrir 9443 al público — solo alcanzable desde la red interna del proyecto o vía túnel SSH (`gcloud compute ssh --tunnel-through-iap` o similar).
    - Confirmar que el firewall interno permite que la VM llegue a PostgreSQL (5432) y a Dnato por su puerto correspondiente dentro de la misma VPC.
-6. **Orden de ejecución en la VM** (una vez creada y con acceso SSH):
+   - **`firewalld` dentro de la VM**: la [doc oficial de GCP](https://docs.cloud.google.com/compute/docs/images/os-details) confirma para AlmaLinux/CentOS que "por defecto se permite todo el tráfico a través del firewall del guest, porque las reglas de firewall de la VPC lo overridean" — la sección de Rocky Linux específicamente no está en esa página, pero es la misma familia de imagen RHEL-like, así que es razonable esperar el mismo comportamiento. **No verificado 1:1 para Rocky** — al llegar a este paso, correr `sudo firewall-cmd --state` y, si está `running`, confirmar con `sudo firewall-cmd --list-all` que 80/443 pasan (o agregarlos con `firewall-cmd --add-port=80/tcp --add-port=443/tcp --permanent && firewall-cmd --reload`) antes de asumir que alcanza con la regla de la VPC.
+6. **Instalar JDK 21 Temurin** (requisito de WSO2 4.6.0 — verificado contra [adoptium.net/installation/linux](https://adoptium.net/installation/linux/), repo RPM oficial con soporte explícito para Rocky Linux):
+   ```bash
+   sudo tee /etc/yum.repos.d/adoptium.repo <<'EOF'
+   [Adoptium]
+   name=Adoptium
+   baseurl=https://packages.adoptium.net/artifactory/rpm/rocky/$releasever/$basearch
+   enabled=1
+   gpgcheck=1
+   gpgkey=https://packages.adoptium.net/artifactory/api/gpg/key/public
+   EOF
+   sudo dnf install -y temurin-21-jdk
+   java -version   # debe mostrar "21.x.x"
+   ```
+   `install-apim.sh`/`install-mi.sh` detectan `JAVA_HOME` automáticamente a partir del `java` instalado (o respetan `$JAVA_HOME` si ya está seteado) y lo escriben en el unit de systemd — a diferencia de DEV (`doc/infra/wso2-install.md`), acá no alcanza con `/etc/profile.d`, porque systemd no lo lee.
+7. **Orden de ejecución en la VM** (una vez creada y con acceso SSH):
    ```bash
    git clone <este repo> && cd traz-tools/deploy/gcp
    cp .env.example .env   # completar con los valores reales
@@ -119,8 +134,8 @@ Pasos manuales — Claude Code no tiene acceso a la consola de GCP y no ejecuta 
    sudo systemctl start wso2am
    sudo systemctl start wso2mi
    ```
-7. **Smoke test** (equivalente al de DEV en `doc/infra/wso2-install.md` §5): `curl -I https://mcp.cloudtrazalog.com` debe responder con el cert de Let's Encrypt (no self-signed), y proxyear al Gateway del APIM.
-8. **Antes de dar de alta al primer cliente**: aplicar la config de identidad (ADR-008/009) y cerrar la migración de DataServices a PostgreSQL — ninguna de las dos está cubierta por esta tarea.
+8. **Smoke test** (equivalente al de DEV en `doc/infra/wso2-install.md` §5): `curl -I https://mcp.cloudtrazalog.com` debe responder con el cert de Let's Encrypt (no self-signed), y proxyear al Gateway del APIM.
+9. **Antes de dar de alta al primer cliente**: aplicar la config de identidad (ADR-008/009) y cerrar la migración de DataServices a PostgreSQL — ninguna de las dos está cubierta por esta tarea.
 
 ---
 

--- a/doc/v3/deployment-gcp.md
+++ b/doc/v3/deployment-gcp.md
@@ -102,11 +102,66 @@ Pasos manuales — Claude Code no tiene acceso a la consola de GCP y no ejecuta 
 2. **Crear la VM**: tipo `e2-medium`, zona `us-east1-b`, imagen **Rocky Linux 9** (decisión ya tomada en IDR-001, ver 1.1 — no Ubuntu ni CentOS 7), disco 20 GB pd-standard.
    - **Ojo con la variante de imagen**: en el selector de GCP puede aparecer "Rocky Linux 10 optimized for GCP with out-of-tree GVNIC (GVE) Support". **No usar la 10** — la [matriz oficial de compatibilidad de WSO2 4.6.0](https://apim.docs.wso2.com/en/4.6.0/install-and-setup/setup/reference/product-compatibility/) lista `Rocky Linux 8.7`/`9.3` como testeados; Rocky 10/RHEL 10 no figura ahí. GVNIC solo aporta en tráfico intensivo o familias de máquina específicas (C3, N2D, Tau T2D) — irrelevante para un `e2-medium` de 1-2 usuarios. Si existe una variante "Rocky Linux 9 optimized for GCP" (con o sin GVNIC), esa sí sirve igual.
 3. **Reservar IP pública estática** y asociarla a la VM.
+
+   Al crear la VM (paso 2), GCP le asigna una IP pública **efímera** (cambia si se reinicia). Hay que promoverla a estática para que `mcp.cloudtrazalog.com` no se rompa en cada reinicio.
+
+   Con `gcloud` (desde la máquina local, proyecto "Trazalog" seleccionado):
+   ```bash
+   # ver la IP efímera actual de la VM
+   gcloud compute instances describe NOMBRE_VM --zone=us-east1-b \
+     --format="get(networkInterfaces[0].accessConfigs[0].natIP)"
+
+   # promoverla a estática (usar la IP que devolvió el comando anterior)
+   gcloud compute addresses create mcp-cloudtrazalog-ip \
+     --region=us-east1 \
+     --addresses=LA_IP_DEL_COMANDO_ANTERIOR
+   ```
+   Por consola: `VPC network` → `IP addresses` → la IP de la VM aparece como "In use" / "Ephemeral" → botón **"Reserve Static Address"** en esa fila. Queda asociada a la misma VM sin tocar nada más.
+
 4. **DNS**: apuntar `mcp.cloudtrazalog.com` (registro A) a la IP estática reservada en el paso 3.
+
+   Se hace en el panel de quien administra hoy el DNS de `cloudtrazalog.com` (fuera de GCP, salvo que ese dominio use Cloud DNS) — probablemente el mismo lugar donde está configurado el DNS de v2.
+   - Tipo: **A**
+   - Nombre/Host: **mcp** (o `mcp.cloudtrazalog.com` completo, según el proveedor)
+   - Valor: la IP estática del paso 3
+   - TTL: default del proveedor
+
+   Verificar propagación (puede tardar de minutos a un par de horas):
+   ```bash
+   dig +short mcp.cloudtrazalog.com
+   # o: nslookup mcp.cloudtrazalog.com
+   ```
+   Tiene que devolver la IP estática reservada.
+
 5. **Firewall del proyecto GCP**:
-   - Abrir **80/tcp** (requerido por el desafío HTTP-01 de Let's Encrypt) y **443/tcp** (tráfico público real), origen `0.0.0.0/0`.
-   - **NO** abrir 9443 al público — solo alcanzable desde la red interna del proyecto o vía túnel SSH (`gcloud compute ssh --tunnel-through-iap` o similar).
-   - Confirmar que el firewall interno permite que la VM llegue a PostgreSQL (5432) y a Dnato por su puerto correspondiente dentro de la misma VPC.
+   - **Usar una etiqueta de red (tag), no "todas las instancias"** — el proyecto ya tiene otras VMs corriendo (Dnato, PostgreSQL, la VM legacy WSO2 4.4); una regla sin scope les abriría 80/443 también a ellas.
+     ```bash
+     # etiquetar la VM nueva (si no se hizo al crearla)
+     gcloud compute instances add-tags NOMBRE_VM --zone=us-east1-b --tags=mcp-gateway
+
+     # regla de firewall, solo para instancias con esa etiqueta
+     gcloud compute firewall-rules create allow-mcp-http-https \
+       --network=default \
+       --direction=INGRESS \
+       --action=ALLOW \
+       --rules=tcp:80,tcp:443 \
+       --source-ranges=0.0.0.0/0 \
+       --target-tags=mcp-gateway
+     ```
+     (si la red no se llama `default`, chequear con `gcloud compute networks list` y ajustar `--network`)
+   - **NO** crear ninguna regla que abra 9443 al público. GCP deniega todo ingreso por defecto salvo que exista una regla `ALLOW` explícita — mientras no se cree una, ya está cerrado. Confirmar que no exista ya una regla vieja demasiado permisiva:
+     ```bash
+     gcloud compute firewall-rules list --format="table(name,sourceRanges.list(),allowed[].map().firewall_rule().list(),targetTags.list())"
+     ```
+     Si aparece algo con `0.0.0.0/0` y rango de puertos amplio (`0-65535` o similar), no tocarlo sin confirmar antes qué lo usa.
+   - **Conectividad interna a PostgreSQL/Dnato**: PostgreSQL corre en una VM propia (`traz-db-prod`, no es Cloud SQL administrado — ver `TRAZALOG_v3_MCP_ARCHITECTURE.md` §10.5), así que la conectividad depende de compartir la misma red VPC, no de reglas de firewall nuevas. Si el proyecto usa la red `default`, ya existe la regla `default-allow-internal` que permite todo el tráfico interno entre VMs del proyecto — solo hace falta confirmar que la VM nueva quedó en esa misma red:
+     ```bash
+     gcloud compute instances describe NOMBRE_VM --zone=us-east1-b \
+       --format="get(networkInterfaces[0].network)"
+     gcloud compute instances describe NOMBRE_VM_POSTGRES --zone=us-east1-b \
+       --format="get(networkInterfaces[0].network)"
+     ```
+     Si ambos comandos devuelven la misma red, está cubierto. Si difieren, hace falta peering o una regla específica — no asumir, chequear antes de seguir.
    - **`firewalld` dentro de la VM**: la [doc oficial de GCP](https://docs.cloud.google.com/compute/docs/images/os-details) confirma para AlmaLinux/CentOS que "por defecto se permite todo el tráfico a través del firewall del guest, porque las reglas de firewall de la VPC lo overridean" — la sección de Rocky Linux específicamente no está en esa página, pero es la misma familia de imagen RHEL-like, así que es razonable esperar el mismo comportamiento. **No verificado 1:1 para Rocky** — al llegar a este paso, correr `sudo firewall-cmd --state` y, si está `running`, confirmar con `sudo firewall-cmd --list-all` que 80/443 pasan (o agregarlos con `firewall-cmd --add-port=80/tcp --add-port=443/tcp --permanent && firewall-cmd --reload`) antes de asumir que alcanza con la regla de la VPC.
 6. **Instalar JDK 21 Temurin** (requisito de WSO2 4.6.0 — verificado contra [adoptium.net/installation/linux](https://adoptium.net/installation/linux/), repo RPM oficial con soporte explícito para Rocky Linux):
    ```bash


### PR DESCRIPTION
## Qué cambia
Sizing verificado de la VM GCP para el early adopter minero (ADR-011) + scripts de instalación NATIVA (sin Docker) de WSO2 APIM 4.6.0 + MI, con systemd y reverse proxy Caddy (TLS Let's Encrypt automático).

## Por qué
E7-INFRA-01/02 — ADR-011 dejó pendiente investigar el sizing exacto contra doc oficial de GCP y producir los artefactos de instalación nativa para reemplazar el túnel ngrok antes de activar al primer cliente early adopter.

## Cómo lo verifiqué
- Sizing (e2-micro/small/medium/standard-2) verificado contra doc oficial de GCP (specs, pricing de referencia, condiciones Always Free) y requisitos oficiales de WSO2 APIM 4.6.0 (`apim.docs.wso2.com`) — ver `doc/v3/deployment-gcp.md` §1 con fuentes citadas.
- Templating de `deployment.toml` (hostname + `database.apim_db`/`database.shared_db` → PostgreSQL, con el campo `type = "postgre"` verificado contra la doc oficial) probado con un archivo TOML sintético — output correcto.
- `bash -n` sobre los 3 scripts (`install-apim.sh`, `install-mi.sh`, `setup-reverse-proxy.sh`) — sintaxis válida.
- Verificado `grep` de marcadores de conflicto — ninguno introducido por esta rama.
- **No se ejecutó nada contra una VM real** — no hay acceso a la consola de GCP de Rodolfo. Ver checklist manual en `doc/v3/deployment-gcp.md` §4.

## Puntos que requieren decisión de Rodolfo (no autoimplementados)
- **Costo real (~US$50-60/mes) vs. ADR-005 ($0 hasta 2027)**: el free tier de GCP solo cubre `e2-micro` (1GB), insuficiente para el APIM según su propio mínimo oficial (4GB). El tier mínimo viable (`e2-standard-2`) no es gratis — ver §1.4.
- Región/VPC exacta donde ya viven Dnato y PostgreSQL (no investigable sin acceso a la consola).
- Config de identidad (ADR-008/009, Key Manager federado Dnato) y migración de DataServices a PostgreSQL quedan explícitamente fuera de alcance (clase 🔴 / trabajo en curso aparte) — no se tocaron.

Closes #E7-INFRA-01, #E7-INFRA-02