### PR TITLE
docs: relevamiento para unificación de Virtual MCP Servers [E2-MCP-10-RELEV]

### DIFF
--- a/doc/v3/STATE.md
+++ b/doc/v3/STATE.md
@@ -14,31 +14,35 @@
 
 **Sprint actual:** Sprint 3 — Activación early adopter minero
 **Objetivo del sprint:** Reemplazar ngrok por un despliegue estable en GCP (ADR-011) y cerrar la deuda técnica pendiente antes de activar al primer cliente early adopter.
-**Última actualización:** 2026-07-28 por Claude Code (E7-INFRA-01/02)
+**Última actualización:** 2026-07-31 por Claude Code (E2-MCP-10-RELEV)
 
 ### Tareas activas
 
 | ID | Descripción | Clase | Estado | Rama / PR |
 |---|---|---|---|---|
-| E7-INFRA-01/02 | Sizing VM GCP + scripts instalación nativa WSO2 (ADR-011) | 🟡 | **Completada** — VM creada, APIM+MI arriba, reverse proxy con TLS funcionando | PR #403 (mergeado) — fixes post-merge en `fix/e7-infra-01-02-post-merge-followups` (pendiente de abrir PR) |
-| E1-API-20 | Relevamiento de estado para dimensionar Sprint 3 (3 frentes) | 🟢 | Completada | `docs/e1-api-20-sprint3-relevamiento-estado` — PR pendiente de abrir |
+| E2-MCP-10-RELEV | Relevamiento para unificación de Virtual MCP Servers (Bloque 0) | 🟢 | **Completada** — ver `doc/v3/relevamiento-unificacion-mcp.md` | `docs/e2-mcp-10-relev-unificacion-mcp` — PR abierto, sin mergear |
+| E7-INFRA-01/02 | Sizing VM GCP + scripts instalación nativa WSO2 (ADR-011) | 🟡 | **Completada y mergeada** — VM funcionando end-to-end | PR #403 y #404 mergeados |
+| ADR-012 | Aislamiento y alcance de Almacenes | — | **Aprobado y mergeado** | PR #405 |
+| Sprint 3 kickoff | Kickoff + artefacto de prompts (`sprint-3-prompts.md`) | — | Mergeado | PR #406 |
+| E1-API-20 | Relevamiento de estado para dimensionar Sprint 3 (3 frentes) | 🟢 | Completada | `docs/e1-api-20-sprint3-relevamiento-estado` — PR pendiente de abrir (Bloque 1 de `sprint-3-prompts.md`, no ejecutado en esta sesión) |
 
 ### Próxima acción
 
-E7-INFRA-01/02 completada: la VM en `us-east1-b` tiene WSO2 APIM 4.6.0 + MI 4.5.0 corriendo nativamente sobre Rocky Linux 9, con Caddy sirviendo TLS en `mcp.cloudtrazalog.com`. Falta abrir PR de `fix/e7-infra-01-02-post-merge-followups` → `develop-v3` con todos los fixes encontrados durante la ejecución real (ver decisiones recientes) y, antes de dar de alta al primer cliente, resolver lo que quedó explícitamente fuera de esta tarea: identidad (ADR-008/009) y migración de DataServices a PostgreSQL (ver Bloqueos). En paralelo, sigue pendiente que Rodolfo responda las 5 preguntas abiertas de `doc/v3/sprint-3-relevamiento-estado.md` (especialmente el riesgo de seguridad en `ALMDataService` — §2).
+Bloque 0 de `sprint-3-prompts.md` completado: `doc/v3/relevamiento-unificacion-mcp.md` responde las 2 preguntas técnicas para el ADR-013. Hallazgo clave: WSO2 4.6.0 **no permite combinar varias APIs en un solo Virtual MCP Server** (el wizard exige una API fuente única) — la unificación real requiere consolidar las operaciones de mantenimiento + almacenes en **una sola** API de WSO2 con rutas prefijadas por módulo, y generar un único MCP Server desde ahí (Opción A recomendada en el documento). **Próximo paso: CW + Rodolfo cierran el ADR-013 en workshop** usando este relevamiento — recién ahí se desbloquea el Bloque 3 de `sprint-3-prompts.md` (almacenes), que hoy espera esa decisión. En paralelo siguen pendientes: Bloque 1 (abrir PR de `docs/e1-api-20-sprint3-relevamiento-estado`, no ejecutado en esta sesión), Bloque 2 (E7-INFRA-03, identidad en la VM nueva), y que Rodolfo responda las preguntas abiertas de `doc/v3/sprint-3-relevamiento-estado.md`.
 
 ### Decisiones recientes (últimas 5)
 
 | Fecha | Decisión | Referencia |
 |---|---|---|
-| 2026-07-28 | E7-INFRA-01/02 completada en la práctica: VM levantada, APIM+MI corriendo. Aparecieron y se corrigieron 2 problemas reales no cubiertos por el checklist original: (1) registro interno del APIM se dejó en H2 embebida en vez de PostgreSQL, decisión explícita de Rodolfo (acota ADR-011 punto 6, nota agregada al ADR); (2) SELinux (Enforcing por defecto en Rocky/GCP) bloqueaba la ejecución de los binarios tras el `mv` desde el temp de descompresión — se agregó `restorecon -R` a `install-apim.sh`/`install-mi.sh` | `doc/v3/deployment-gcp.md`, ADR-011, `fix/e7-infra-01-02-post-merge-followups` |
-| 2026-07-27 | PR #403 mergeado a `develop-v3`. Durante la ejecución del checklist apareció un 404 real en el repo RPM de Adoptium para JDK 21 (`rocky/9` no existe, solo `rocky/8`) — corregido a `rhel/9` (Rocky 9 es compatible 1:1 con RHEL 9) | `doc/v3/deployment-gcp.md`, PR #403 |
-| 2026-07-24 | Corregido el SO de la VM GCP: `Rocky Linux 9` (no Ubuntu, error de la v1 del doc). Ya estaba decidido en IDR-001 (`TRAZALOG_v3_MCP_ARCHITECTURE.md` §9-10) por incompatibilidad de CentOS 7/glibc con JDK 21 — no es una decisión nueva | `doc/v3/deployment-gcp.md`, PR #403 |
-| 2026-07-21 | Sizing final de la VM GCP: `e2-medium` (2 vCPU/4GB), no `e2-standard-2`. Rodolfo priorizó costo (~US$24/mes) + volumen real (1-2 usuarios) por sobre el mínimo "de catálogo" de WSO2, con heaps chicos ya validados en su DEV | `doc/v3/deployment-gcp.md`, PR #403 |
-| 2026-07-16 | Relevamiento Sprint 3 completo: Mantenimiento con diseño listo para implementar, Almacenes con lógica de negocio ya existente pero gap de seguridad multi-tenant sin resolver, Despliegue GCP arranca de cero en artefactos | `doc/v3/sprint-3-relevamiento-estado.md` |
+| 2026-07-31 | Relevamiento de unificación MCP completado: 1 API WSO2 = 1 Virtual MCP Server (no se pueden combinar varias APIs), confirmado contra doc oficial 4.6.0 + evidencia del propio entorno (equipos/OTs ya comparten backend MI pero tienen APIs y MCP Servers separados). Recomendación técnica: consolidar man+alm en una sola API con rutas prefijadas por módulo | `doc/v3/relevamiento-unificacion-mcp.md` |
+| 2026-07-30 | ADR-012 aprobado y mergeado: Almacenes reusa el patrón de Mantenimiento (empr_id del JWT, crear_pedido_materiales con BPM+rollback estilo create_ot), alcance limitado a pedidos (sin operaciones de stock) | PR #405, `doc/adr/ADR-012-almacenes-aislamiento.md` |
+| 2026-07-28 | E7-INFRA-01/02 completada en la práctica: VM levantada, APIM+MI corriendo. Se corrigieron 2 problemas reales no cubiertos por el checklist original: (1) registro interno del APIM en H2 embebida en vez de PostgreSQL (decisión explícita de Rodolfo, acota ADR-011 punto 6); (2) SELinux bloqueaba los binarios tras el `mv` del temp de descompresión — se agregó `restorecon -R` a los install scripts | PR #404, `doc/v3/deployment-gcp.md`, ADR-011 |
+| 2026-07-27 | PR #403 mergeado a `develop-v3`. 404 real en el repo RPM de Adoptium para JDK 21 (`rocky/9` no existe, solo `rocky/8`) — corregido a `rhel/9` | `doc/v3/deployment-gcp.md`, PR #403 |
+| 2026-07-24 | Corregido el SO de la VM GCP: `Rocky Linux 9` (no Ubuntu). Ya estaba decidido en IDR-001 por incompatibilidad de CentOS 7/glibc con JDK 21 | `doc/v3/deployment-gcp.md`, PR #403 |
 
 ### Bloqueos
 
-- Config de identidad (ADR-008/009) y migración de DataServices a PostgreSQL siguen pendientes antes de poder dar de alta al primer cliente sobre esta VM — fuera de alcance de E7-INFRA-01/02.
-- La implementación de escritura MCP en Almacenes sigue bloqueada hasta que el PM confirme cómo resolver el aislamiento multi-tenant de `ALMDataService` (ver pregunta abierta #1 del relevamiento) — posible tema de arquitectura (🔴).
+- **Bloque 3 de `sprint-3-prompts.md` (tools MCP de Almacenes) espera el ADR-013** (unificación MCP) — no ejecutar hasta que CW+Rodolfo lo cierren con el relevamiento de `doc/v3/relevamiento-unificacion-mcp.md`.
+- Config de identidad (ADR-008/009) y migración de DataServices a PostgreSQL siguen pendientes antes de poder dar de alta al primer cliente sobre la VM de GCP — cubierto por E7-INFRA-03 (Bloque 2 de `sprint-3-prompts.md`, no ejecutado todavía).
+- La implementación de escritura MCP en Almacenes sigue bloqueada hasta que el PM confirme cómo resolver el aislamiento multi-tenant de `ALMDataService` (ver pregunta abierta #1 del relevamiento de Sprint 3) — posible tema de arquitectura (🔴).
 

--- a/doc/v3/relevamiento-unificacion-mcp.md
+++ b/doc/v3/relevamiento-unificacion-mcp.md
@@ -1,0 +1,122 @@
+# Relevamiento — Unificación de Virtual MCP Servers (E2-MCP-10-RELEV)
+
+> Tarea: E2-MCP-10-RELEV — Bloque 0 de `doc/v3/sprint-3-prompts.md`. Clase 🟢 (relevamiento, no modifica nada).
+> Objetivo: responder con datos reales dos preguntas técnicas para que CW + Rodolfo cierren el **ADR-013 (unificación MCP)** sin adivinar. Este documento NO implementa la unificación.
+
+---
+
+## Metodología y limitación honesta
+
+Claude Code (esta sesión) **no tiene acceso a la consola WSO2 APIM real** (ni credenciales, ni red hacia la VM de GCP ni hacia el DEV de Rodolfo) — no pudo "entrar y mirar" en vivo, a pesar de que el prompt de la tarea lo pedía. Para no adivinar, esta investigación se apoya en dos fuentes que sí son verificables:
+
+1. **Documentación oficial de WSO2 API Manager 4.6.0** (`apim.docs.wso2.com/en/4.6.0/...`), consultada activamente para esta tarea, citada con URL.
+2. **Artefactos y documentación YA EXISTENTES en este repo** que registran configuración REAL hecha en esa misma consola durante el Sprint 2 (`doc/mcp/virtual-mcp-equipos.md`, `doc/mcp/virtual-mcp-ots.md`, `doc/api/openapi-publish-procedure.md`, y los fuentes WSO2 MI en `_backend/api/ToolsAPIProject/.../artifacts/apis/`). Estos no son "documentación genérica del producto" — son el registro de lo que Rodolfo/CW efectivamente configuraron y verificaron en este entorno.
+
+Donde estas dos fuentes no alcanzan para responder con certeza, lo marco explícitamente como pregunta abierta (sección final), en vez de inventar.
+
+---
+
+## Pregunta 1 — ¿Se puede agrupar varias APIs en un solo Virtual MCP Server?
+
+### Respuesta corta: no, no de forma directa. El wizard de WSO2 4.6.0 exige una sola API como fuente.
+
+**Lo que dice la documentación oficial** (verificado contra `apim.docs.wso2.com/en/4.6.0/ai-gateway/mcp-gateway/overview/`): WSO2 API Manager 4.6.0 ofrece exactamente **tres** caminos para crear un MCP Server:
+
+1. **From OpenAPI Definition** — "Generate tools and configuration from an existing OpenAPI" (una sola spec OpenAPI).
+2. **From Existing API** — "Select an **API** already in APIM and convert operations into MCP tools" (singular: se selecciona UNA API, y de ahí un subconjunto de sus operaciones).
+3. **Proxy External MCP Server** — "Wrap an external MCP server for governance, security, and analytics."
+
+Ninguno de los tres caminos menciona **API Products** (el mecanismo nativo de WSO2 para combinar recursos de varias APIs en un consumible único) como fuente válida para generar un MCP Server. La documentación no dice "no se puede" en esas palabras, pero tampoco ofrece ningún mecanismo para combinar operaciones de APIs *distintas* en un solo MCP Server — el flujo 2 (el que usamos en Sprint 2) opera sobre **una** API, seleccionando un subconjunto de **sus propias** operaciones.
+
+**Lo que confirma el entorno real (Sprint 2):** `doc/mcp/virtual-mcp-equipos.md` y `doc/mcp/virtual-mcp-ots.md` documentan que se crearon **dos APIs separadas** en el Publisher (`EquiposAPI-TrazalogMCP` y `OrdenesdeTrabajoAPI-TrazalogMCP`), cada una con su **propio** Virtual MCP Server (`trazalog-equipos`, `trazalog-ots`) — a pesar de que ambas apuntan al **mismo backend MI** (`http://<host>:8280/tools/man`, ver `doc/api/openapi-publish-procedure.md` líneas 77-80 y 152-153). Si WSO2 4.6.0 permitiera agrupar varias APIs en un MCP Server, este habría sido el caso ideal para hacerlo (mismo backend, mismo dominio funcional) — y no se hizo así, lo cual es consistente con que el wizard no lo permite.
+
+### El camino real para lograr el objetivo (un solo MCP Server con tools de man+alm)
+
+No se logra combinando *APIs* distintas en un MCP Server. Se logra **consolidando las operaciones en UNA sola API de WSO2** (con las rutas prefijadas por módulo dentro de esa única API, ej. `/mcp/man/equipos`, `/mcp/man/ot`, `/mcp/alm/pedidos`) y generando el MCP Server **desde esa API única**. Hay precedente arquitectónico de esto en el propio repo: a nivel del **MI** (no del Publisher), `toolsMANAPI.xml` (context `/tools/man`) ya implementa los recursos de **equipos y OTs juntos** dentro de un mismo artefacto WSO2 — la consolidación por módulo dentro de una sola API ya se practica, solo que hoy se corta en dos APIs distintas recién al nivel del Publisher/MCP Server.
+
+### Aclaración importante sobre "prefijos por URL"
+
+El Virtual MCP Server expone **una sola URL** (`https://<host>/<nombre-del-server>/1.0/mcp` — ver `doc/v3/CONTEXT-PACK.md` §4, ya confirmado en los dos servers existentes). El protocolo MCP no rutea por path después de esa URL única: los tool calls van todos por JSON-RPC (`tools/call` con un parámetro `name`), no por URLs distintas por tool. Es decir: **no existe un "prefijo de URL" navegable por el agente dentro del MCP Server** — lo que sí puede (y hoy ya) llevar prefijo/estructura por módulo son:
+- Las **rutas REST internas** de la API fuente (`/mcp/man/...`, `/mcp/alm/...`), que determinan de qué operación sale cada tool.
+- Los **nombres de las tools** generadas (`get_equipos`, `get_pedido_material`, etc.) — hoy no llevan prefijo (`man_`, `alm_`), simplemente son nombres únicos por dominio. Si al unificar se quiere namespacing explícito en el nombre de la tool, es una decisión de diseño (no una restricción técnica), a definir en el ADR-013.
+
+---
+
+## Pregunta 2 — ¿Cómo están estructuradas HOY las APIs con recursos MCP de mantenimiento?
+
+### A nivel MI (backend real): una sola API, con recursos MCP y no-MCP mezclados
+
+`_backend/api/ToolsAPIProject/ToolsAPIProject/src/main/wso2mi/artifacts/apis/toolsMANAPI.xml` (context `/tools/man`) es **una única API WSO2 MI** que implementa:
+- `GET /mcp/equipo/{equi_id}` — MCP
+- `GET /mcp/equipos` — MCP
+- `POST /mcp/ot` — MCP (create_ot, con BPM + rollback)
+- `GET /mcp/ot` — MCP
+- `GET /mcp/ot/{id_solicitud}` — MCP
+- `POST /solicitudServicio?bpmSession={bpmSession}` — **NO es MCP**, es un recurso preexistente (probablemente ligado al flujo BPM/v2 anterior a la capa MCP; no se investigó su consumidor actual, fuera de alcance de esta tarea).
+
+Es decir: a nivel MI, los recursos `/mcp/*` de mantenimiento (equipos + OTs) **conviven en la misma API** que al menos un recurso no-MCP. No es una API "limpia" dedicada 100% a MCP en este nivel.
+
+### A nivel APIM/Publisher (la capa que se virtualiza como MCP Server): dos APIs dedicadas, creadas específicamente para MCP
+
+`doc/api/equipos.yaml` (`Equipos API — Trazalog MCP`) y `doc/api/ot.yaml` (`Órdenes de Trabajo API — Trazalog MCP`) son **dos specs OpenAPI separadas**, publicadas como **dos APIs independientes** en el Publisher (`EquiposAPI-TrazalogMCP`, `OrdenesdeTrabajoAPI-TrazalogMCP` — ver `doc/api/openapi-publish-procedure.md`, tarea E1-API-10). Ninguna de las dos es una API de v2 reutilizada — **ambas se crearon nuevas, específicamente para exponer MCP** (por eso el sufijo `-TrazalogMCP` en el nombre). Cada una solo incluye en su spec las operaciones `/mcp/*` que le corresponden — el recurso no-MCP `/solicitudServicio` del MI **no está expuesto** en ninguna de las dos.
+
+Ambas APIs, aunque separadas a nivel Publisher, apuntan al **mismo backend MI** (`http://<host>:8280/tools/man`, el mismo `toolsMANAPI`). Por eso hoy hay **2 Virtual MCP Servers** (`trazalog-equipos`, `trazalog-ots`) sobre un único backend compartido.
+
+### Resumen de la estructura real
+
+| Capa | Equipos + OTs |
+|---|---|
+| MI (`toolsMANAPI.xml`, `/tools/man`) | **Una sola API**, mezcla recursos `/mcp/*` de ambos dominios + 1 recurso no-MCP (`/solicitudServicio`) |
+| Publisher/APIM | **Dos APIs separadas**, creadas nuevas para MCP (`EquiposAPI-TrazalogMCP`, `OrdenesdeTrabajoAPI-TrazalogMCP`), cada una con su propio Virtual MCP Server |
+
+---
+
+## Opciones de unificación
+
+### Opción A — Consolidar en una sola API WSO2 (Publisher) con rutas prefijadas por módulo, y generar UN Virtual MCP Server desde ahí
+
+Fusionar `equipos.yaml` + `ot.yaml` + la futura spec de almacenes en **una sola** spec OpenAPI (rutas del estilo `/mcp/man/equipos`, `/mcp/man/ot`, `/mcp/alm/pedidos`), publicarla como **una** API en el Publisher, y generar **un único** Virtual MCP Server desde ella (ej. `trazalog-operaciones`).
+
+- **Pros:** es el único camino soportado nativamente por el producto según la Pregunta 1 (1 API → 1 MCP Server); reusa exactamente el patrón ya probado en Sprint 2 (selección de operaciones desde una API); no requiere componentes nuevos (Python/FastMCP).
+- **Contras:** implica **deprecar** `trazalog-equipos` y `trazalog-ots` (y sus URLs actuales) — hay que migrar la config de Claude.ai de la demo a la URL nueva. También implica trabajo en el MI: consolidar (o crear un nuevo artefacto) que sirva los recursos de mantenimiento + almacenes bajo una estructura de rutas coherente por módulo.
+
+### Opción B — No tocar equipos/ots; crear el server unificado solo para módulos nuevos hacia adelante
+
+Dejar `trazalog-equipos` y `trazalog-ots` como están, y unificar únicamente los módulos que todavía no existen (empezando por almacenes) en un nuevo Virtual MCP Server aparte.
+
+- **Pros:** cero riesgo inmediato sobre lo que ya funciona en la demo; no bloquea la entrega de almacenes esperando una migración.
+- **Contras:** no es una unificación real — quedarían 2 o más MCP Servers igual, contradice el objetivo de fondo que motivó esta tarea ("un solo MCP Server con todo"); pospone indefinidamente el trabajo de consolidación si nadie lo prioriza después.
+
+### Opción C — Server intermedio en Python/FastMCP que agregue las APIs existentes ("proxy" del wizard, camino 3)
+
+Construir un MCP Server externo (Python/FastMCP) que internamente llame a las APIs WSO2 existentes (equipos, ots, almacenes) y las re-exponga unificadas con namespacing propio, gobernado por el WSO2 Gateway vía la opción "Proxy External MCP Server".
+
+- **Pros:** control total sobre el namespacing/prefijos de las tools, sin las restricciones del wizard "from existing API".
+- **Contras:** contradice directamente **ADR-002** ("maximizar Virtual MCP Servers autogenerados, minimizar Python/FastMCP") — esa decisión reserva Python solo para capacidades que WSO2 no puede replicar, y la Opción A demuestra que WSO2 SÍ puede lograr la unificación sin código nuevo. Suma latencia de doble salto (riesgo ya documentado en `TRAZALOG_v3_MCP_ARCHITECTURE.md`, tabla de riesgos) y una capa operativa nueva sin necesidad real.
+
+### Recomendación técnica
+
+**Opción A.** Es la única que logra el objetivo real (un Virtual MCP Server único) usando el producto tal como está pensado, sin contradecir ADR-002 como sí hace la Opción C, y sin dejar la unificación a medias como la Opción B. El costo de la Opción A (romper las URLs de `trazalog-equipos`/`trazalog-ots`) es una ventana de migración coordinable — no un bloqueo técnico — descrita en la siguiente sección.
+
+---
+
+## Impacto sobre lo que ya funciona
+
+- **`trazalog-equipos` y `trazalog-ots` dejarían de existir** (o quedarían deprecados) si se adopta la Opción A. Antes de dar de baja cualquiera de los dos, hace falta:
+  - Crear y verificar completamente el MCP Server unificado (incluyendo un smoke test de las 5 tools actuales: `get_equipos`, `get_equipo`, `get_ots`, `get_ot`, `create_ot`, más las que sume almacenes).
+  - Reconfigurar el cliente de Claude.ai de la demo con la URL nueva (`Settings → Integrations → MCP Servers`) — es un paso manual, sencillo, pero hay que coordinarlo con quien haga la próxima demo para que no la encuentre rota.
+  - Recién ahí despublicar/deprecar los dos servers viejos.
+- **En el MI**, `toolsMANAPI` (o un artefacto nuevo que lo reemplace) tendría que crecer para servir también los recursos de almacenes bajo una estructura de rutas coherente por módulo — esto es trabajo de implementación real, no cubierto por esta tarea de relevamiento.
+- **Riesgo para la demo que ya anda:** bajo si se coordina la ventana de corte (crear lo nuevo → verificar → recién migrar → recién deprecar lo viejo). Alto solo si se apaga `trazalog-equipos`/`trazalog-ots` antes de tener el reemplazo probado.
+
+---
+
+## Preguntas abiertas (no determinables sin acceso a la consola real o sin arriesgar lo que ya funciona)
+
+1. **¿WSO2 4.6.0 permite configurar un *endpoint* distinto por recurso dentro de una misma API del Publisher?** Esto importa si al consolidar man+alm en una sola API se quiere mantener el backend MI *separado* por módulo (en vez de fusionar también el MI). No lo pude confirmar contra la doc oficial ni contra el entorno real — requiere probarlo a mano en una copia de prueba de una API antes de decidir el diseño final del ADR-013.
+2. **¿Los nombres de las tools deberían llevar prefijo explícito** (`man_get_equipos`, `alm_get_pedidos`) **o alcanza con nombres únicos sin colisión** (como hoy)? Hoy no hay colisión de nombres entre equipos/ots y lo que se conoce de almacenes (ADR-012). Es una decisión de UX/diseño para el agente, no una restricción técnica — la dejo para el workshop del ADR-013.
+3. **¿Se pueden tener 2+ Virtual MCP Servers activos en paralelo durante la ventana de migración** (viejo + nuevo) **sin que se pisen entre sí?** Son entidades independientes en APIM, así que la expectativa razonable es que sí — pero no está verificado explícitamente contra el entorno real ni contra la doc oficial, lo marco como supuesto de bajo riesgo, no como hecho confirmado.
+
+---
+
+*Generado para E2-MCP-10-RELEV, Bloque 0 de `doc/v3/sprint-3-prompts.md`. No modifica ninguna configuración de MCP Servers ni APIs existentes — es solo relevamiento.*


### PR DESCRIPTION
## Qué cambia
Agrega `doc/v3/relevamiento-unificacion-mcp.md`: responde con datos reales las 2 preguntas técnicas que bloquean el ADR-013 (unificación de Virtual MCP Servers) — (1) si WSO2 4.6.0 permite agrupar varias APIs en un solo MCP Server (no), y (2) cómo están estructuradas hoy las APIs de mantenimiento (MI: una API mezcla MCP+no-MCP; Publisher: dos APIs separadas dedicadas a MCP). Incluye 3 opciones de unificación con pros/contras, recomendación técnica, e impacto sobre `trazalog-equipos`/`trazalog-ots`. No implementa nada — es solo relevamiento (Bloque 0 de `doc/v3/sprint-3-prompts.md`).

## Por qué
Bloque 0 de `doc/v3/sprint-3-prompts.md` — desbloquea el workshop del ADR-013 (Rodolfo quiere unificar los Virtual MCP Servers separados en uno solo con tools prefijadas por módulo). El Bloque 3 (tools MCP de Almacenes) espera esta decisión.

## Cómo lo verifiqué
- Documentación oficial de WSO2 API Manager 4.6.0 (`apim.docs.wso2.com/en/4.6.0/ai-gateway/mcp-gateway/overview/`), consultada activamente y citada con URL.
- Artefactos reales del repo que registran configuración ya hecha en la consola WSO2 durante Sprint 2: `doc/mcp/virtual-mcp-equipos.md`, `doc/mcp/virtual-mcp-ots.md`, `doc/api/openapi-publish-procedure.md`, y los fuentes WSO2 MI en `_backend/api/ToolsAPIProject/.../artifacts/apis/toolsMANAPI.xml`.
- Limitación declarada explícitamente en el documento: sin acceso a la consola WSO2 real en esta sesión (sin credenciales ni red hacia la VM/DEV) — no se pudo verificar en vivo, solo contra las dos fuentes de arriba.
- `STATE.md` actualizado (incluye sincronización con PRs #403-#406 ya mergeados fuera de esta sesión).

No mergear — review de Rodolfo / CW.