### PR TITLE
docs: prompts Sprint 3 con unificación MCP (ADR-013)

### DIFF
--- a/doc/v3/sprint-3-prompts.md
+++ b/doc/v3/sprint-3-prompts.md
@@ -1,4 +1,4 @@
-# Sprint 3 — Prompts para Claude Code (frente INFRA)
+# Sprint 3 — Prompts para Claude Code
 
 > **Cómo se usa este archivo:**
 > - Rodolfo le dice a Claude Code: *"Leé doc/v3/sprint-3-prompts.md y doc/v3/STATE.md. Ejecutá la próxima tarea pendiente (o el próximo bloque encadenable), respetando los bloqueos marcados."*
@@ -11,73 +11,9 @@
 
 ---
 
-## BLOQUE 0 — Relevamiento para unificación MCP (E2-MCP-10-RELEV) [PR PROPIO] ⭐ PRÓXIMA TAREA
+## BLOQUE 0 — Relevamiento para unificación MCP (E2-MCP-10-RELEV) ✅ COMPLETADO
 
-> **Contexto:** Rodolfo quiere unificar los Virtual MCP Servers separados (equipos, ots, y el futuro almacenes) en UN SOLO MCP Server con todas las tools, URLs prefijadas por módulo (ej. `/man/...`, `/alm/...`). Esto es un cambio de arquitectura (ADR-013, pendiente) que toca lo que YA funciona en producción-demo. Antes de decidir el ADR, hace falta relevar terreno real: ni CW ni Rodolfo tienen certeza de dos cosas técnicas.
->
-> **Esta tarea va PRIMERO en el frente de unificación. Bloquea el ADR-013 y, por lo tanto, la construcción final de almacenes** (porque se decidió que almacenes nazca dentro del MCP unificado).
-
-```
-╔════════════════════════════════════════════╗
-║ REPO: traz-tools → /mnt/win/dev/git/traz-tools ║
-╚════════════════════════════════════════════╝
-
-Leé doc/v3/CONTEXT-PACK.md, doc/v3/STATE.md y doc/v3/TRAZALOG_v3_MCP_ARCHITECTURE.md
-(sección de Virtual MCP Servers) antes de empezar.
-
-Tarea: E2-MCP-10-RELEV — Relevamiento para la unificación de los Virtual MCP Servers.
-Clase: 🟢 (relevamiento + documento, no modifica nada de la config actual).
-
-OBJETIVO: responder con datos reales dos preguntas que hoy no tienen certeza, para
-que el PM+CW decidan el ADR-013 (unificación MCP) sin adivinar. NO implementar la
-unificación — solo relevar y reportar.
-
-CONTEXTO ARQUITECTÓNICO (confirmado): el flujo real de Trazalog es
-DataServices (MI) → APIs WSO2 (con recursos /mcp/... que derivan empr_id del
-X-JWT-Assertion, nunca del caller) → Virtual MCP Server (APIM 4.6). En el Sprint 2
-se crearon Virtual MCP Servers SEPARADOS (uno para equipos, uno para OTs).
-
-PREGUNTA 1 — ¿Se puede agrupar varias APIs en un solo Virtual MCP Server?
-- Investigá, en la consola WSO2 APIM 4.6 real de este entorno Y en la documentación
-  oficial de la versión 4.6, si un Virtual MCP Server puede componerse tomando
-  operaciones/tools de VARIAS APIs WSO2 distintas (ej: toolsMANAPI + toolsALMAPI en
-  un mismo MCP Server), o si cada Virtual MCP Server se ata a UNA sola API/OpenAPI.
-- Si se puede agrupar: documentá el mecanismo exacto (cómo se seleccionan las tools
-  de cada API, cómo se manejan las URLs/prefijos, si permite prefijo por módulo tipo
-  /man/ y /alm/).
-- Si NO se puede agrupar varias APIs: documentá la alternativa real (ej: una sola API
-  WSO2 grande con todas las operaciones prefijadas → un MCP Server; o cualquier otro
-  patrón que el producto soporte). NO inventes: si la doc/consola no lo aclara,
-  decilo explícitamente.
-
-PREGUNTA 2 — ¿Cómo están estructuradas HOY las APIs con recursos MCP de mantenimiento?
-- Relevá en el repo (artefactos WSO2 en _backend/) y/o en la consola: los recursos
-  MCP de mantenimiento (/mcp/equipo, /mcp/ot, etc.), ¿viven en una API DEDICADA a MCP
-  (creada nueva para esto), o en una API WSO2 PREEXISTENTE (de v2) a la que se le
-  agregaron los recursos /mcp/... junto a otros recursos no-MCP?
-- Documentá: nombre real de la(s) API(s), qué recursos tiene cada una (cuáles son
-  /mcp/ y cuáles no), y si equipos y OTs comparten una API o están en APIs separadas.
-
-ENTREGABLE: doc/v3/relevamiento-unificacion-mcp.md con:
-- Respuesta a Pregunta 1 (con cita a la doc oficial 4.6 o a lo visto en consola)
-- Respuesta a Pregunta 2 (estructura real de las APIs de mantenimiento)
-- Una sección "Opciones de unificación" que, según lo relevado, liste los caminos
-  viables reales para lograr UN solo MCP Server con tools de man+alm prefijadas por
-  módulo, con pros/contras de cada uno y una recomendación técnica.
-- Una sección "Impacto sobre lo que ya funciona": qué habría que tocar de los Virtual
-  MCP Servers actuales (equipos, ots) y qué riesgo tiene para la demo que ya anda.
-
-REGLAS:
-- Solo relevamiento. NO modifiques la configuración de los MCP Servers actuales ni
-  las APIs.
-- Verificá contra la doc OFICIAL de WSO2 4.6 y contra el entorno real — no asumas
-  del comportamiento genérico del producto.
-- Si algo no se puede determinar sin romper lo que anda, decilo como pregunta abierta.
-- Actualizá STATE.md al terminar.
-- PR con formato obligatorio, sin mergear.
-```
-
-> **Después del Bloque 0:** CW + Rodolfo leen el relevamiento y cierran el **ADR-013 (unificación MCP)** en un workshop corto. Recién ahí se define si los prompts de almacenes (Bloque 3) se ejecutan como están (server propio) o se reescriben para nacer dentro del MCP unificado.
+> **✅ Hecho.** Entregable: `doc/v3/relevamiento-unificacion-mcp.md`. Resultado: WSO2 4.6 no permite agrupar varias APIs en un MCP Server → la unificación se logra con una API fachada única. El workshop ADR-013 cerró con esa decisión. Ver Bloque 3 para la implementación.
 
 ---
 
@@ -186,159 +122,214 @@ NO mergees. Review de Rodolfo.
 
 ---
 
-## BLOQUE 3 — Almacenes (ADR-012 aprobado) — tools MCP ⚠️ ESPERA ADR-013
+## BLOQUE 3 — Unificación MCP + Almacenes (ADR-013) — la fachada toolsMCPAPI
 
-> **⚠️ NO ejecutar todavía.** El ADR-012 (aislamiento y alcance de almacenes) está aprobado, pero Rodolfo decidió que **almacenes nazca dentro del MCP unificado**. Por lo tanto, estos prompts dependen del ADR-013 (unificación MCP), que se decide después del Bloque 0 (relevamiento).
+> **Desbloqueado:** el workshop ADR-013 cerró. `doc/adr/ADR-013-unificacion-mcp.md` está en el repo. La decisión: una fachada MI DELGADA (`toolsMCPAPI`) que resuelve empr_id una vez y rutea a los DataServices existentes, expuesta como UN SOLO Virtual MCP Server con tools prefijadas por módulo (`man_`, `alm_`).
 >
-> **Qué puede cambiar según el ADR-013:** hoy la tarea 3.3 asume un Virtual MCP Server propio (`trazalog-almacenes`). Si la unificación define un MCP Server único, la 3.3 se reescribe para que almacenes se sume al server unificado en vez de crear uno separado. Las tareas 3.1 (lecturas) y 3.2 (crear_pedido) probablemente NO cambian — construyen la API WSO2 `toolsALMAPI`, que es independiente de cómo se agrupe el MCP Server. CW confirmará esto al cerrar el ADR-013.
->
-> **Orden real:** Bloque 0 (relevamiento) → workshop ADR-013 → CW ajusta este bloque si hace falta → recién ahí se ejecuta.
+> **Orden estricto:** 3.1 → 3.2 → 3.3 → 3.4 → 3.5, en secuencia. Cada una es **[PR PROPIO]**.
+> **Regla de tests (decisión del PM):** cada tarea que construya o modifique una tool deja sus tests automatizados como parte del DoD — NO hay tarea de smoke test aparte.
 
-### Tarea 3.1 — toolsALMAPI: las 3 operaciones de LECTURA (E1-ALM-01) [PR PROPIO]
+### Tarea 3.1 — Verificar ruteo múltiple + crear el esqueleto de toolsMCPAPI (E2-MCP-11) [PR PROPIO]
 
 ```
 ╔════════════════════════════════════════════╗
 ║ REPO: traz-tools → /mnt/win/dev/git/traz-tools ║
 ╚════════════════════════════════════════════╝
 
-Leé doc/v3/CONTEXT-PACK.md, doc/v3/STATE.md y doc/adr/ADR-012-almacenes-aislamiento.md
-antes de empezar.
+Leé doc/v3/CONTEXT-PACK.md, doc/v3/STATE.md, doc/adr/ADR-013-unificacion-mcp.md y
+doc/v3/relevamiento-unificacion-mcp.md antes de empezar.
 
-Tarea: E1-ALM-01 — Crear el wrapper toolsALMAPI con las operaciones de LECTURA de
-almacenes, inyectando empr_id desde el JWT (patrón ADR-009).
+Tarea: E2-MCP-11 — Verificar el ruteo a múltiples DataServices y crear el esqueleto
+de la fachada toolsMCPAPI.
+Clase: 🔴 (toca la arquitectura MCP; primer paso de la unificación).
+
+PASO 1 OBLIGATORIO — VERIFICACIÓN (parada obligatoria si falla):
+El ADR-013 (decisión #6) asume que un artefacto MI puede rutear a varios DataServices
+(MANDataService y ALMDataService) desde una sola API. Es lo normal en WSO2 MI, pero el
+relevamiento no lo confirmó en vivo. ANTES de construir nada:
+- Hacé una prueba mínima: un artefacto/recurso MI que llame a DOS DataServices distintos.
+- Si funciona → seguí al paso 2.
+- Si NO funciona o encontrás una limitación → PARÁ, documentá qué pasó, y consultá a
+  Rodolfo. NO improvises un workaround.
+
+PASO 2 — Esqueleto de toolsMCPAPI:
+- Creá el artefacto MI toolsMCPAPI (nuevo, context propio, ej. /tools/mcp) como
+  FACHADA DELGADA: NO reimplementa lógica, solo resolverá empr_id (sequence
+  EmprIdFromHeader, ADR-009) y ruteará a los DataServices/lógica existentes.
+- En esta tarea, implementá SOLO UNA tool de prueba de punta a punta (ej.
+  man_get_equipos) para validar el patrón completo: EmprIdFromHeader → ruteo a
+  MANDataService → respuesta. Con prefijo man_ en el nombre.
+- Dejá el esqueleto preparado para sumar el resto de las tools en las tareas siguientes.
+
+DoD:
+- [ ] Verificación de ruteo múltiple documentada (funciona / no funciona)
+- [ ] toolsMCPAPI creado con EmprIdFromHeader y una tool de prueba (man_get_equipos)
+- [ ] empr_id derivado del JWT, nunca del caller
+- [ ] Tests automatizados de la tool de prueba
+- [ ] STATE.md actualizado
+- [ ] PR con formato obligatorio, sin mergear
+
+🔴 Parada obligatoria en el PASO 1 si el ruteo múltiple no funciona. Ante cualquier
+otra duda, PARÁ y consultá a Rodolfo.
+```
+
+### Tarea 3.2 — Migrar las tools de mantenimiento a la fachada (E2-MCP-12) [PR PROPIO]
+
+```
+╔════════════════════════════════════════════╗
+║ REPO: traz-tools → /mnt/win/dev/git/traz-tools ║
+╚════════════════════════════════════════════╝
+
+Leé CONTEXT-PACK, STATE y ADR-013. Requiere E2-MCP-11 mergeado.
+
+Tarea: E2-MCP-12 — Migrar las 5 tools de mantenimiento a toolsMCPAPI con prefijo man_.
 Clase: 🟡
 
-Contexto: Las tools de almacenes reusan EXACTAMENTE el patrón de Mantenimiento
-(toolsMANAPI). El ALMDataService ya existe y hace lectura/escritura contra la BD,
-igual que MANDataService. El gap a cerrar: hoy ALMDataService recibe empr_id como
-parámetro del caller — en el wrapper NUNCA debe aceptarse empr_id como parámetro;
-se deriva del X-JWT-Assertion vía la sequence EmprIdFromHeader (idéntico a Mantenimiento).
+Sumá a la fachada toolsMCPAPI el resto de las tools de mantenimiento, replicando el
+patrón validado en 3.1:
+- man_get_equipos (ya en 3.1), man_get_equipo, man_get_ots, man_get_ot, man_create_ot
+- Rutas internas prefijadas: /mcp/man/...
+- man_create_ot mantiene el patrón BPM + rollback ya probado en toolsMANAPI (NO
+  reimplementar la lógica: la fachada rutea a lo existente).
+- empr_id del JWT en todas.
 
-Alcance de lectura (según ADR-012):
-- Consultar stock / artículos / movimientos (nombre exacto de la query: relevalo del
-  ALMDataService existente)
-- get_pedidos_materiales (lista de pedidos de la empresa) — análoga a get_ots
-- get_pedido_material (detalle de un pedido; vacío si es de otra empresa) — análoga a get_ot
-
-Acciones:
-1. Estudiá cómo está resuelto toolsMANAPI (endpoints /mcp/... , uso de emprIdFromHeader,
-   estructura de las sequences de lectura) — es el molde a replicar.
-2. Relevá en ALMDataService las queries de lectura disponibles (stock/artículos/
-   movimientos, pedidos, detalle de pedido) y sus parámetros reales.
-3. Creá toolsALMAPI con las 3 operaciones de lectura, cada una:
-   - Derivando empr_id del header validado (EmprIdFromHeader), NUNCA del caller.
-   - Con el filtrado por empresa a nivel SQL.
-4. Si al relevar el ALMDataService encontrás que la estructura NO es análoga a
-   MANDataService (ej: nombres de columnas de empresa distintos, o falta el filtro
-   empr_id en alguna query) → PARÁ y consultá a Rodolfo. NO improvises el aislamiento.
+IMPORTANTE: esto NO toca todavía los Virtual MCP Servers viejos (trazalog-equipos/ots)
+— siguen activos. Solo se construye la fachada en paralelo. La migración del cliente
+se hace en 3.4.
 
 DoD:
-- [ ] toolsALMAPI con las 3 operaciones de lectura, empr_id del JWT (no del caller)
-- [ ] Verificado: no se puede pasar empr_id de otra empresa (aislamiento a nivel gateway)
+- [ ] Las 5 tools de mantenimiento en toolsMCPAPI con prefijo man_
+- [ ] man_create_ot con BPM+rollback funcionando (ruteo, no reimplementación)
+- [ ] Tests automatizados de cada tool
 - [ ] STATE.md actualizado
 - [ ] PR con formato obligatorio, sin mergear
 
-Ante cualquier duda funcional o de arquitectura: PARÁ y consultá a Rodolfo.
+Ante cualquier duda, PARÁ y consultá a Rodolfo.
 ```
 
-### Tarea 3.2 — crear_pedido_materiales con BPM+rollback (E1-ALM-02) [PR PROPIO]
+### Tarea 3.3 — Sumar almacenes a la fachada (E1-ALM-01/02 unificadas) [PR PROPIO]
 
 ```
 ╔════════════════════════════════════════════╗
 ║ REPO: traz-tools → /mnt/win/dev/git/traz-tools ║
 ╚════════════════════════════════════════════╝
 
-Leé doc/v3/CONTEXT-PACK.md, doc/v3/STATE.md y doc/adr/ADR-012-almacenes-aislamiento.md
-antes de empezar. Requiere E1-ALM-01 ya mergeado.
+Leé CONTEXT-PACK, STATE, ADR-012 y ADR-013. Requiere E2-MCP-12 mergeado.
 
-Tarea: E1-ALM-02 — Agregar la operación de ESCRITURA crear_pedido_materiales a
-toolsALMAPI, con el mismo patrón de create_ot (BPM Bonita + rollback).
-Clase: 🔴 (escritura que dispara proceso externo sobre datos reales)
+Tarea: E1-ALM — Sumar las tools de almacenes a toolsMCPAPI con prefijo alm_.
+Clase: 🔴 (incluye crear_pedido con escritura + BPM).
 
-Contexto (ADR-012): crear_pedido_materiales es análoga a create_ot. Dispara un
-proceso Bonita igual que create_ot, con el MISMO patrón de sequence de mediación:
-INSERT del pedido → instancia el proceso BPM → si Bonita falla, rollback (DELETE
-del pedido). NO toca stock (un pedido es una solicitud, no un movimiento de inventario).
+Según ADR-012 (alcance almacenes) + ADR-013 (fachada unificada), agregá a toolsMCPAPI:
+- Lecturas (análogas a mantenimiento): alm_get_stock (o el nombre real de la query de
+  stock/artículos/movimientos que releves del ALMDataService), alm_get_pedidos_materiales,
+  alm_get_pedido_material. Rutas /mcp/alm/...
+- Escritura: alm_crear_pedido_materiales — replica el patrón de man_create_ot (INSERT +
+  BPM Bonita + rollback). NO toca stock (es una solicitud). Annotation de confirmación
+  (openWorldHint).
+- empr_id del JWT en todas (cierra el gap de seguridad del relevamiento: ALMDataService
+  hoy recibe empr_id del caller; en la fachada NUNCA se acepta como parámetro).
 
-Acciones:
-1. Estudiá cómo está implementado create_ot en toolsMANAPI: la sequence de mediación,
-   el INSERT, la llamada a Bonita, y el rollback (DELETE si Bonita falla). Es el molde EXACTO.
-2. Identificá en ALMDataService la query de creación de pedido de materiales y el
-   proceso Bonita correspondiente (nombre del proceso, parámetros que espera).
-3. Implementá crear_pedido_materiales replicando el patrón de create_ot:
-   - empr_id del JWT (EmprIdFromHeader), nunca del caller.
-   - INSERT del pedido → instancia BPM → rollback en caso de fallo.
-   - La tool debe pedir confirmación explícita del usuario (annotation tipo
-     openWorldHint, igual que create_ot).
-4. PUNTOS DE PARADA OBLIGATORIA (consultá a Rodolfo, NO decidas):
-   - Si el proceso Bonita del pedido de materiales tiene un nombre/estructura que NO
-     conocés o no encontrás.
-   - Si el payload del pedido requiere campos cuyo significado no está claro
-     (ej: tipo de material, depósito destino, prioridad).
-   - Si el patrón de rollback de create_ot no aplica limpiamente por alguna diferencia.
+PUNTOS DE PARADA OBLIGATORIA (🔴): si no conocés el proceso Bonita del pedido, el
+payload real (campos del pedido), o si el ALMDataService no es análogo a MANDataService
+→ PARÁ y consultá a Rodolfo.
 
 DoD:
-- [ ] crear_pedido_materiales funcionando con INSERT + BPM + rollback
-- [ ] empr_id del JWT; annotation de confirmación (openWorldHint)
-- [ ] Verificado que el rollback dispara si Bonita falla (no quedan pedidos huérfanos)
+- [ ] 3 lecturas + alm_crear_pedido_materiales en toolsMCPAPI, prefijo alm_
+- [ ] Aislamiento verificado: no se puede pasar empr_id de otra empresa
+- [ ] crear_pedido con BPM+rollback + confirmación; verificado que el rollback dispara
+- [ ] Tests automatizados de cada tool (incluida la prueba de aislamiento 2 empresas)
 - [ ] STATE.md actualizado
 - [ ] PR con formato obligatorio, sin mergear
 
-Esta es clase 🔴: ante CUALQUIER duda sobre el proceso BPM, el payload, o el rollback,
-PARÁ y consultá a Rodolfo antes de implementar.
+🔴 Paradas obligatorias marcadas arriba. Ante cualquier duda, PARÁ y consultá a Rodolfo.
 ```
 
-### Tarea 3.3 — OpenAPI spec + Virtual MCP Server almacenes (E1-ALM-03) [PR PROPIO]
+### Tarea 3.4 — Publicar la API + Virtual MCP Server único + migración coordinada (E2-MCP-13) [PR PROPIO]
 
 ```
 ╔════════════════════════════════════════════╗
 ║ REPO: traz-tools → /mnt/win/dev/git/traz-tools ║
 ╚════════════════════════════════════════════╝
 
-Leé doc/v3/CONTEXT-PACK.md, doc/v3/STATE.md y doc/adr/ADR-012-almacenes-aislamiento.md
-antes de empezar. Requiere E1-ALM-01 y E1-ALM-02 ya mergeados.
+Leé CONTEXT-PACK, STATE y ADR-013. Requiere E1-ALM (3.3) mergeado.
 
-Tarea: E1-ALM-03 — OpenAPI spec alm.yaml + Virtual MCP Server trazalog-almacenes.
+Tarea: E2-MCP-13 — OpenAPI unificada + Virtual MCP Server único + guía de migración.
+Clase: 🟡 (el trabajo de consola lo hace Rodolfo; Code prepara los artefactos y la guía).
+
+1. Creá la spec OpenAPI unificada doc/api/trazalog-operaciones.yaml con TODAS las tools
+   (man_* + alm_*), descripciones semánticas, empr_id AUSENTE de los parámetros de
+   request (el gateway lo extrae del JWT), y las annotations de confirmación en las
+   tools de escritura (man_create_ot, alm_crear_pedido_materiales).
+2. Creá doc/mcp/virtual-mcp-unificado.md con:
+   - La tabla completa de tools del server unificado
+   - Los pasos de consola WSO2 para Rodolfo: publicar la API fachada en el Publisher y
+     generar UN Virtual MCP Server (ej. trazalog-operaciones) desde ella.
+   - La GUÍA DE MIGRACIÓN COORDINADA (ADR-013 decisión #5): orden estricto →
+     (a) crear y publicar el unificado, (b) smoke test de las 9 tools, (c) reconfigurar
+     Claude.ai a la URL nueva, (d) RECIÉN ahí despublicar trazalog-equipos y trazalog-ots.
+   - Advertencia explícita: NO despublicar los viejos antes de verificar el nuevo.
+
+DoD:
+- [ ] trazalog-operaciones.yaml con las 9 tools, empr_id ausente de request
+- [ ] virtual-mcp-unificado.md con pasos de consola + guía de migración coordinada
+- [ ] STATE.md actualizado
+- [ ] PR con formato obligatorio, sin mergear
+
+Ante cualquier duda, PARÁ y consultá a Rodolfo.
+```
+
+> **Después de 3.4:** Rodolfo ejecuta en la consola WSO2 (pasos manuales): publica la API fachada, genera el Virtual MCP Server unificado, hace el smoke test de las 9 tools con la prueba de aislamiento de 2 empresas, reconfigura Claude.ai, y recién despublica los viejos. Esta verificación manual es la que en Sprint 2 fue el smoke test — ahora los tests automatizados de cada tarea la respaldan.
+
+### Tarea 3.5 — Desplegar la fachada al server GCP (E7-INFRA-05) [PR PROPIO]
+
+```
+╔════════════════════════════════════════════╗
+║ REPO: traz-tools → /mnt/win/dev/git/traz-tools ║
+╚════════════════════════════════════════════╝
+
+Leé CONTEXT-PACK, STATE, ADR-011 y ADR-013. Requiere E2-MCP-13 mergeado y verificado
+por Rodolfo en DEV.
+
+Tarea: E7-INFRA-05 — Desplegar la fachada toolsMCPAPI + el Virtual MCP Server unificado
+al server de GCP (mcp.cloudtrazalog.com).
 Clase: 🟡
 
-Contexto: Con las 4 operaciones de almacenes ya implementadas (3 lecturas + crear_pedido),
-falta la spec OpenAPI con descripciones semánticas (para que Claude sepa cuándo usar
-cada tool) y la configuración del Virtual MCP Server, siguiendo el patrón de equipos.yaml
-y ot.yaml + sus Virtual MCP Servers.
+Contexto: toolsMCPAPI y el Virtual MCP Server unificado funcionan en el DEV de Rodolfo.
+Falta llevarlos a la VM de GCP (la que E7-INFRA-01/02 dejó lista: APIM 4.6 + MI 4.5
+nativo, Caddy con TLS en mcp.cloudtrazalog.com).
 
-Acciones:
-1. Estudiá doc/api/equipos.yaml y doc/api/ot.yaml como molde (descripciones semánticas,
-   ejemplos de request/response, empr_id AUSENTE de los parámetros de request — solo
-   aparece en response como dato informativo).
-2. Creá doc/api/alm.yaml con las 4 tools:
-   - Las 3 de lectura + crear_pedido_materiales
-   - Descripciones orientadas a que Claude sepa cuándo usarlas
-   - empr_id NUNCA como parámetro de request (securitySchemes explica que el gateway
-     lo extrae del JWT)
-   - crear_pedido_materiales marcada con la annotation de confirmación
-3. Creá doc/mcp/virtual-mcp-almacenes.md con la tabla de tools + pasos de consola WSO2
-   para crear el Virtual MCP Server trazalog-almacenes (patrón de URL:
-   /trazalog-almacenes/1.0/mcp — usa el NOMBRE del server, no el de la API).
-4. Actualizá el CONTEXT-PACK si corresponde (nueva entrada en la tabla "si tu tarea
-   toca X → leé Y" para almacenes).
+1. Preparar los artefactos desplegables (el CApp/CAR del MI con toolsMCPAPI, la config
+   de la API para el APIM) y documentar el procedimiento de despliegue al server GCP.
+2. Como el despliegue en sí requiere acceso a la VM (que solo tiene Rodolfo): dejá un
+   checklist claro en doc/v3/deployment-gcp.md (sección "Despliegue de la fachada MCP")
+   con los pasos que Rodolfo ejecuta en el server: desplegar el CAR al MI, publicar la
+   API y el Virtual MCP Server en el APIM de la VM, verificar el flujo OAuth end-to-end
+   contra mcp.cloudtrazalog.com.
+3. Incluí en el checklist la verificación de que el aislamiento multi-tenant funciona
+   también en el server GCP (prueba de 2 empresas contra la URL pública).
 
 DoD:
-- [ ] doc/api/alm.yaml con las 4 tools, empr_id ausente de request
-- [ ] doc/mcp/virtual-mcp-almacenes.md con tabla + pasos de consola
+- [ ] Artefactos desplegables preparados
+- [ ] Checklist de despliegue al server GCP en deployment-gcp.md
+- [ ] Verificación de aislamiento incluida en el checklist
 - [ ] STATE.md actualizado
 - [ ] PR con formato obligatorio, sin mergear
 
-Ante cualquier duda: PARÁ y consultá a Rodolfo.
+Ante cualquier duda (sobre todo si el despliegue difiere de lo que quedó documentado
+en E7-INFRA), PARÁ y consultá a Rodolfo.
 ```
 
-> **Después del Bloque 3:** Rodolfo publica la API en el Publisher y configura el Virtual MCP Server en la consola WSO2 (pasos manuales, como en Sprint 2), y hace el smoke test de las 4 tools de almacenes con la prueba de aislamiento de 2 empresas.
+> **Después del Bloque 3:** el MCP unificado está corriendo en GCP, con las 9 tools (mantenimiento + almacenes), aislamiento verificado, listo para el early adopter. Queda el frente de negocio (deck, auditoría de datos del cliente, sesión guiada) del kickoff.
 
----
 
 ## Estado de este archivo
 
-- **⭐ Próxima tarea:** Bloque 0 (relevamiento de unificación MCP) — desbloquea el ADR-013.
-- **Desbloqueado y listo:** Bloque 0 → Bloque 1 (2 PRs, ya mergeados #403/#404) → Bloque 2 (identidad E7-INFRA-03).
-- **Espera decisión de arquitectura (ADR-013):** Bloque 3 (almacenes) — porque almacenes nace dentro del MCP unificado.
-- **Nota:** E1-ALM-02 (crear_pedido_materiales) es clase 🔴 con puntos de parada obligatoria.
-- CW actualiza este archivo a medida que se destraban los bloques (próximo ajuste: tras el ADR-013).
+- **✅ Completado:** Bloque 0 (relevamiento) → ADR-013 cerrado y mergeado.
+- **Desbloqueado y listo para ejecutar (en orden):**
+  - Bloque 2 (identidad E7-INFRA-03) — independiente, se puede hacer cuando quieras
+  - Bloque 3 completo, secuencial: 3.1 (fachada + verificación ruteo 🔴) → 3.2 (mantenimiento a la fachada) → 3.3 (almacenes 🔴) → 3.4 (publicar + Virtual MCP único + migración) → 3.5 (desplegar a GCP)
+- **Bloque 1:** ya mergeado (#403/#404).
+- **Paradas obligatorias 🔴:** Tarea 3.1 (verificación de ruteo múltiple) y 3.3 (proceso Bonita/payload de almacenes).
+- **Tests:** cada tarea deja sus tests automatizados (decisión del PM, sin tarea de smoke test aparte).
+- **Pendiente fuera de este archivo:** frente de negocio del kickoff (deck, auditoría de datos del cliente, sesión guiada) — no es trabajo de Claude Code.
+- CW actualiza este archivo a medida que se destraban los bloques.


### PR DESCRIPTION
## Qué cambia
Bloque 3 reescrito: la secuencia de la fachada toolsMCPAPI (3.1 esqueleto+verificación → 3.2 mantenimiento → 3.3 almacenes → 3.4 publicación+migración → 3.5 despliegue GCP). Incluye tests en cada DoD y despliegue a GCP.

## Por qué
Refleja el ADR-013 (unificación MCP con fachada delgada).

## Cómo lo verifiqué
Prompts derivados del ADR-013 y del relevamiento E2-MCP-10-RELEV.