### PR TITLE
feat(mcp): verificar ruteo múltiple + esqueleto de toolsMCPAPI [E2-MCP-11]

### DIFF
--- a/_backend/api/ToolsAPIProject/ToolsAPIProject/src/main/wso2mi/artifacts/apis/toolsMCPAPI.xml
+++ b/_backend/api/ToolsAPIProject/ToolsAPIProject/src/main/wso2mi/artifacts/apis/toolsMCPAPI.xml
@@ -1,0 +1,84 @@
+<api xmlns="http://ws.apache.org/ns/synapse" name="toolsMCPAPI" context="/tools/mcp">
+   <!-- ══════════════════════════════════════════════════════════════
+        E2-MCP-11 (ADR-013): fachada ÚNICA y DELGADA de la capa MCP.
+
+        Esta API NO reimplementa lógica de negocio. Por cada tool:
+          1. Resuelve empr_id UNA vez (sequence emprIdFromHeader, ADR-009 —
+             la misma que ya usa toolsMANAPI, sin cambios).
+          2. Rutea al DataService/lógica que YA existe (mismo patrón que
+             toolsMANAPI: fn:concat($ctx:dataservices_url, '/<DataService>/...')).
+
+        Reemplaza, resource por resource, a los recursos /mcp/* hoy repartidos
+        entre toolsMANAPI (y, cuando se sumen, los de almacenes) — ver ADR-013
+        decisión #1 y #2. Rutas internas prefijadas por módulo: /mcp/man/...,
+        /mcp/alm/... (decisión #2). Nombres de tool con prefijo man_/alm_
+        (decisión #3) — el nombre de tool lo define la spec OpenAPI que se
+        publique en el Publisher (Tarea 3.4), no este artefacto MI.
+
+        Esta tarea (E2-MCP-11) implementa UNA sola tool de punta a punta
+        (man_get_equipos) para validar el patrón completo antes de migrar el
+        resto (Tarea 3.2). Es EXACTAMENTE la misma llamada que ya hace
+        toolsMANAPI en /mcp/equipos (mismo DataService, mismo query, mismo
+        formato de URL) — se copia el patrón verificado, no se reinventa.
+   -->
+
+   <!-- man_get_equipos — lista de equipos activos de la empresa del JWT.
+        Réplica 1:1 del recurso GET /mcp/equipos de toolsMANAPI.xml, bajo la
+        ruta prefijada por módulo que define ADR-013. -->
+   <resource methods="GET" uri-template="/mcp/man/equipos">
+      <inSequence>
+         <!-- ADR-009: deriva empr_id del backend JWT (X-JWT-Assertion) que firma el APIM. -->
+         <sequence key="emprIdFromHeader"/>
+
+         <property xmlns:ns2="http://org.apache.synapse/xsd" xmlns:ns="http://org.apache.synapse/xsd"
+                   name="apiconf"
+                   expression="get-property('registry','conf:tools/apiconfig.xml')"
+                   scope="default" type="OM"/>
+         <property xmlns:ns2="http://org.apache.synapse/xsd" xmlns:ns="http://org.apache.synapse/xsd"
+                   name="dataservices_url"
+                   expression="$ctx:apiconf//dataservices_url"/>
+
+         <!-- usa jwt_mysql_empresa_id (id nativo assetv2) — nunca el empr_id de Postgres -->
+         <property name="uri.var.getEquipos_url"
+                   expression="fn:concat($ctx:dataservices_url,'/MANEquiposDataService/mcp/equipos/',get-property('jwt_mysql_empresa_id'))"/>
+
+         <log level="custom" category="DEBUG">
+            <property name="text"              value="#TRAZA | MCP | man_get_equipos | iniciando (toolsMCPAPI, fachada ADR-013)"/>
+            <property name="mysql_empresa_id"  expression="get-property('jwt_mysql_empresa_id')"/>
+            <property name="url"               expression="$ctx:uri.var.getEquipos_url"/>
+         </log>
+
+         <header name="Accept" scope="transport" value="application/json"/>
+         <!-- ADR-008 fix: un GET sin body NO debe enviar Content-Type: application/json;
+              rompe el JsonStreamBuilder del DSS (NullPointerException: charsetName → 500).
+              El Accept ya define el formato de salida JSON. -->
+         <property name="messageType" scope="axis2" action="remove"/>
+         <property name="ContentType" scope="axis2" action="remove"/>
+         <header name="Content-Type" scope="transport" action="remove"/>
+         <property name="FORCE_ERROR_ON_SOAP_FAULT" value="true" scope="default" type="STRING"/>
+
+         <call>
+            <endpoint>
+               <http method="GET" uri-template="{uri.var.getEquipos_url}"/>
+            </endpoint>
+         </call>
+
+         <filter source="get-property('axis2', 'HTTP_SC')" regex="2[0-9][0-9]">
+            <then>
+               <respond/>
+            </then>
+            <else>
+               <property name="ERROR_MESSAGE" expression="json-eval($)" type="STRING"/>
+               <property name="TOOLS_ERROR" value="GET /mcp/man/equipos - MANEquiposDataService error" type="STRING"/>
+               <sequence key="toolsFault"/>
+            </else>
+         </filter>
+      </inSequence>
+      <faultSequence>
+         <property name="ERROR_MESSAGE" expression="json-eval($)" type="STRING"/>
+         <property name="TOOLS_ERROR" value="Error en MCP man_get_equipos (toolsMCPAPI)" type="STRING"/>
+         <sequence key="toolsFault"/>
+      </faultSequence>
+   </resource>
+
+</api>

--- a/doc/v3/STATE.md
+++ b/doc/v3/STATE.md
@@ -14,35 +14,37 @@
 
 **Sprint actual:** Sprint 3 — Activación early adopter minero
 **Objetivo del sprint:** Reemplazar ngrok por un despliegue estable en GCP (ADR-011) y cerrar la deuda técnica pendiente antes de activar al primer cliente early adopter.
-**Última actualización:** 2026-07-31 por Claude Code (E2-MCP-10-RELEV)
+**Última actualización:** 2026-07-31 por Claude Code (E2-MCP-11)
 
 ### Tareas activas
 
 | ID | Descripción | Clase | Estado | Rama / PR |
 |---|---|---|---|---|
-| E2-MCP-10-RELEV | Relevamiento para unificación de Virtual MCP Servers (Bloque 0) | 🟢 | **Completada** — ver `doc/v3/relevamiento-unificacion-mcp.md` | `docs/e2-mcp-10-relev-unificacion-mcp` — PR abierto, sin mergear |
-| E7-INFRA-01/02 | Sizing VM GCP + scripts instalación nativa WSO2 (ADR-011) | 🟡 | **Completada y mergeada** — VM funcionando end-to-end | PR #403 y #404 mergeados |
-| ADR-012 | Aislamiento y alcance de Almacenes | — | **Aprobado y mergeado** | PR #405 |
-| Sprint 3 kickoff | Kickoff + artefacto de prompts (`sprint-3-prompts.md`) | — | Mergeado | PR #406 |
-| E1-API-20 | Relevamiento de estado para dimensionar Sprint 3 (3 frentes) | 🟢 | Completada | `docs/e1-api-20-sprint3-relevamiento-estado` — PR pendiente de abrir (Bloque 1 de `sprint-3-prompts.md`, no ejecutado en esta sesión) |
+| E2-MCP-11 | Verificar ruteo múltiple + esqueleto de la fachada `toolsMCPAPI` (Bloque 3, tarea 3.1) | 🔴 | **Completada** — ruteo múltiple confirmado, `toolsMCPAPI` creado con `man_get_equipos` end-to-end | `feature/e2-mcp-11-toolsmcpapi-skeleton` — PR abierto, sin mergear |
+| ADR-013 | Unificación MCP: fachada delgada `toolsMCPAPI`, un solo Virtual MCP Server | — | **Aprobado y mergeado** (workshop CW+Rodolfo sobre el relevamiento) | PR #408, `sprint-3-prompts.md` actualizado en PR #409 |
+| E2-MCP-10-RELEV | Relevamiento para unificación de Virtual MCP Servers (Bloque 0) | 🟢 | Completada y mergeada | PR #407 |
+| E7-INFRA-01/02 | Sizing VM GCP + scripts instalación nativa WSO2 (ADR-011) | 🟡 | Completada y mergeada — VM funcionando end-to-end | PR #403 y #404 mergeados |
+| ADR-012 | Aislamiento y alcance de Almacenes | — | Aprobado y mergeado | PR #405 |
+| E1-API-20 | Relevamiento de estado para dimensionar Sprint 3 (3 frentes) | 🟢 | Completada | `docs/e1-api-20-sprint3-relevamiento-estado` — PR pendiente de abrir (Bloque 1 de `sprint-3-prompts.md`, no ejecutado todavía) |
 
 ### Próxima acción
 
-Bloque 0 de `sprint-3-prompts.md` completado: `doc/v3/relevamiento-unificacion-mcp.md` responde las 2 preguntas técnicas para el ADR-013. Hallazgo clave: WSO2 4.6.0 **no permite combinar varias APIs en un solo Virtual MCP Server** (el wizard exige una API fuente única) — la unificación real requiere consolidar las operaciones de mantenimiento + almacenes en **una sola** API de WSO2 con rutas prefijadas por módulo, y generar un único MCP Server desde ahí (Opción A recomendada en el documento). **Próximo paso: CW + Rodolfo cierran el ADR-013 en workshop** usando este relevamiento — recién ahí se desbloquea el Bloque 3 de `sprint-3-prompts.md` (almacenes), que hoy espera esa decisión. En paralelo siguen pendientes: Bloque 1 (abrir PR de `docs/e1-api-20-sprint3-relevamiento-estado`, no ejecutado en esta sesión), Bloque 2 (E7-INFRA-03, identidad en la VM nueva), y que Rodolfo responda las preguntas abiertas de `doc/v3/sprint-3-relevamiento-estado.md`.
+Tarea 3.1 del Bloque 3 completada: el ruteo a múltiples DataServices desde una sola API MI está confirmado (ver decisión de hoy), y `toolsMCPAPI` existe con una tool de punta a punta (`man_get_equipos`) siguiendo el patrón exacto de `toolsMANAPI`. **Próximo paso, en orden estricto (ADR-013): Tarea 3.2** — migrar el resto de las tools de mantenimiento (`man_get_equipo`, `man_get_ots`, `man_get_ot`, `man_create_ot`) a `toolsMCPAPI`, una vez que este PR se revise y mergee. En paralelo siguen pendientes: Bloque 1 (abrir PR de `docs/e1-api-20-sprint3-relevamiento-estado`), Bloque 2 (E7-INFRA-03, identidad en la VM nueva), y que Rodolfo responda las preguntas abiertas de `doc/v3/sprint-3-relevamiento-estado.md`.
 
 ### Decisiones recientes (últimas 5)
 
 | Fecha | Decisión | Referencia |
 |---|---|---|
-| 2026-07-31 | Relevamiento de unificación MCP completado: 1 API WSO2 = 1 Virtual MCP Server (no se pueden combinar varias APIs), confirmado contra doc oficial 4.6.0 + evidencia del propio entorno (equipos/OTs ya comparten backend MI pero tienen APIs y MCP Servers separados). Recomendación técnica: consolidar man+alm en una sola API con rutas prefijadas por módulo | `doc/v3/relevamiento-unificacion-mcp.md` |
+| 2026-07-31 | **E2-MCP-11 — ruteo múltiple CONFIRMADO.** Evidencia estática sólida: `toolsMANAPI` ya rutea distintos resources a distintos DataServices (`MANDataService`, `MANEquiposDataService`) con el mismo mecanismo dinámico (`fn:concat($ctx:dataservices_url,'/<DataService>/...')`), ya verificado en producción. Se intentó además una verificación en vivo real (MI local de Rodolfo, `.car` recién buildeado con `toolsMCPAPI`) — el MI arrancó bien, pero el CAR completo falló al deployar por un timeout de conexión de `ALMDataService` a PostgreSQL (sin ruta de red desde este entorno a esa BD) — **no relacionado a `toolsMCPAPI` ni a la pregunta de ruteo**, solo evidencia que el deploy del CApp es atómico (una falla de conexión de cualquier DataService revierte todo el CAR). `toolsMCPAPI` creado con `man_get_equipos` (réplica exacta de `/mcp/equipos` de `toolsMANAPI`, bajo `/mcp/man/equipos`) | `_backend/api/ToolsAPIProject/.../artifacts/apis/toolsMCPAPI.xml`, ADR-013 |
+| 2026-07-31 | ADR-013 aprobado y mergeado: fachada delgada `toolsMCPAPI` (resuelve empr_id una vez, rutea a DataServices existentes), un solo Virtual MCP Server, tools con prefijo de módulo (`man_`, `alm_`) | PR #408, `doc/adr/ADR-013-unificacion-mcp.md` |
+| 2026-07-31 | Relevamiento de unificación MCP completado: 1 API WSO2 = 1 Virtual MCP Server (no se pueden combinar varias APIs), confirmado contra doc oficial 4.6.0 + evidencia del propio entorno | PR #407, `doc/v3/relevamiento-unificacion-mcp.md` |
 | 2026-07-30 | ADR-012 aprobado y mergeado: Almacenes reusa el patrón de Mantenimiento (empr_id del JWT, crear_pedido_materiales con BPM+rollback estilo create_ot), alcance limitado a pedidos (sin operaciones de stock) | PR #405, `doc/adr/ADR-012-almacenes-aislamiento.md` |
-| 2026-07-28 | E7-INFRA-01/02 completada en la práctica: VM levantada, APIM+MI corriendo. Se corrigieron 2 problemas reales no cubiertos por el checklist original: (1) registro interno del APIM en H2 embebida en vez de PostgreSQL (decisión explícita de Rodolfo, acota ADR-011 punto 6); (2) SELinux bloqueaba los binarios tras el `mv` del temp de descompresión — se agregó `restorecon -R` a los install scripts | PR #404, `doc/v3/deployment-gcp.md`, ADR-011 |
-| 2026-07-27 | PR #403 mergeado a `develop-v3`. 404 real en el repo RPM de Adoptium para JDK 21 (`rocky/9` no existe, solo `rocky/8`) — corregido a `rhel/9` | `doc/v3/deployment-gcp.md`, PR #403 |
-| 2026-07-24 | Corregido el SO de la VM GCP: `Rocky Linux 9` (no Ubuntu). Ya estaba decidido en IDR-001 por incompatibilidad de CentOS 7/glibc con JDK 21 | `doc/v3/deployment-gcp.md`, PR #403 |
+| 2026-07-28 | E7-INFRA-01/02 completada en la práctica: VM levantada, APIM+MI corriendo. SELinux + repo JDK corregidos | PR #404, `doc/v3/deployment-gcp.md`, ADR-011 |
 
 ### Bloqueos
 
-- **Bloque 3 de `sprint-3-prompts.md` (tools MCP de Almacenes) espera el ADR-013** (unificación MCP) — no ejecutar hasta que CW+Rodolfo lo cierren con el relevamiento de `doc/v3/relevamiento-unificacion-mcp.md`.
+- **Tarea 3.3 (Almacenes en la fachada) espera que 3.1 (esta) y 3.2 se mergeen primero** — orden estricto de ADR-013.
 - Config de identidad (ADR-008/009) y migración de DataServices a PostgreSQL siguen pendientes antes de poder dar de alta al primer cliente sobre la VM de GCP — cubierto por E7-INFRA-03 (Bloque 2 de `sprint-3-prompts.md`, no ejecutado todavía).
+- **Nota operativa para cuando se pruebe end-to-end con BD real:** el deploy del `.car` de `ToolsAPIProject` es atómico — si `ALMDataService` (o cualquier otro `.dbs` del proyecto) no puede conectar a su BD al momento del deploy, se revierte el CAR completo, incluida `toolsMCPAPI`. No es un problema de esta tarea, pero vale tenerlo presente para la VM de GCP y para cuando se sumen las DataServices de almacenes (Tarea 3.3).
 - La implementación de escritura MCP en Almacenes sigue bloqueada hasta que el PM confirme cómo resolver el aislamiento multi-tenant de `ALMDataService` (ver pregunta abierta #1 del relevamiento de Sprint 3) — posible tema de arquitectura (🔴).
 

--- a/scripts/dev/mint-backend-jwt.py
+++ b/scripts/dev/mint-backend-jwt.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""
+Genera un valor para el header X-JWT-Assertion, simulando el backend JWT que el
+APIM genera y firma tras validar el JWT de Dnato (ADR-008/ADR-009) — el que
+EmprIdFromHeader.xml (MI) decodifica para derivar empr_id/empr_id_mysql.
+
+No firma con una clave real: EmprIdFromHeader.xml todavía no valida la firma de
+la assertion (ver su propio comentario "PROD: validar la firma..."), solo hace
+Base64.decode() del segundo segmento y parsea el JSON — por eso alcanza con
+armar el shape header.payload.signature (3 segmentos) que el parser espera.
+
+Uso:
+    python3 scripts/dev/mint-backend-jwt.py [empr_id] [empr_id_mysql]
+    python3 scripts/dev/mint-backend-jwt.py 42 42
+
+Imprime solo el valor en stdout (apto para X-JWT-Assertion: $(...)).
+
+SOLO DEV/testing — no reemplaza el backend JWT real que firma el APIM en producción.
+"""
+import base64
+import json
+import sys
+import time
+
+empr_id = int(sys.argv[1]) if len(sys.argv) > 1 else 42
+empr_id_mysql = int(sys.argv[2]) if len(sys.argv) > 2 else empr_id
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
+
+
+def _seg(obj: dict) -> str:
+    return _b64url(json.dumps(obj, separators=(",", ":")).encode())
+
+
+now = int(time.time())
+header = {"alg": "none", "typ": "JWT"}
+payload = {"empr_id": empr_id, "empr_id_mysql": empr_id_mysql, "iat": now}
+
+# tercer segmento vacío (sin firma) — EmprIdFromHeader solo exige 3 partes separadas por "."
+print(f"{_seg(header)}.{_seg(payload)}.")

--- a/tests/security/mcp-facade-man-get-equipos.hurl
+++ b/tests/security/mcp-facade-man-get-equipos.hurl
@@ -1,0 +1,57 @@
+# E2-MCP-11 (ADR-013) — Tests de la fachada toolsMCPAPI, tool man_get_equipos
+#
+# Este test llama al MI DIRECTAMENTE (:8290), sin pasar por el APIM — mismo
+# patrón que mi-fallback.hurl. Simula el header X-JWT-Assertion que en
+# producción genera y firma el APIM (ADR-008/ADR-009); EmprIdFromHeader.xml
+# todavía no valida esa firma (ver su propio comentario "PROD: validar la
+# firma..."), así que alcanza con el shape que arma mint-backend-jwt.py.
+#
+# Pre-requisitos:
+#   1. MI corriendo con el CAR de ToolsAPIProject actualizado (incluye
+#      toolsMCPAPI.xml) deployado — ver scripts/dev/setup-mi-b4-car-deploy.sh
+#   2. Conectividad real a la BD que usa MANEquiposDataService (para que el
+#      Caso C devuelva 200 con datos reales, no solo "no 503")
+#
+# Variables requeridas:
+#   MI_HOST        = host:port del MI (ej: localhost:8290)
+#   VALID_ASSERTION = valor de X-JWT-Assertion con empr_id/empr_id_mysql —
+#                      generar con: python3 scripts/dev/mint-backend-jwt.py 42 42
+#
+# Ejecutar:
+#   ASSERTION=$(python3 scripts/dev/mint-backend-jwt.py 42 42)
+#   hurl --variable MI_HOST=localhost:8290 --variable VALID_ASSERTION="$ASSERTION" \
+#        mcp-facade-man-get-equipos.hurl
+
+
+# ─────────────────────────────────────────────────────────────────
+# Caso A: sin X-JWT-Assertion → 503 identity_missing (EmprIdFromHeader,
+# fail-closed — nunca sigue sin poder resolver empr_id)
+# ─────────────────────────────────────────────────────────────────
+GET http://{{MI_HOST}}/tools/mcp/mcp/man/equipos
+HTTP 503
+[Asserts]
+jsonpath "$.error" == "identity_missing"
+
+
+# ─────────────────────────────────────────────────────────────────
+# Caso B: X-JWT-Assertion mal formado (no tiene 3 segmentos) → 503
+# identity_missing, igual que el caso sin header (fail-closed)
+# ─────────────────────────────────────────────────────────────────
+GET http://{{MI_HOST}}/tools/mcp/mcp/man/equipos
+X-JWT-Assertion: no-es-un-jwt-valido
+HTTP 503
+[Asserts]
+jsonpath "$.error" == "identity_missing"
+
+
+# ─────────────────────────────────────────────────────────────────
+# Caso C: X-JWT-Assertion con empr_id válido → NO 503 (EmprIdFromHeader
+# resolvió empr_id y la fachada ruteó a MANEquiposDataService). Sin BD
+# real alcanzable, lo importante es que NO sea 503 — igual criterio que
+# mi-fallback.hurl Caso C.
+# ─────────────────────────────────────────────────────────────────
+GET http://{{MI_HOST}}/tools/mcp/mcp/man/equipos
+X-JWT-Assertion: {{VALID_ASSERTION}}
+HTTP *
+[Asserts]
+status != 503


### PR DESCRIPTION
## Qué cambia
Tarea 3.1 del Bloque 3 (ADR-013). Verifica que un artefacto MI puede rutear a múltiples DataServices desde una sola API (requisito de la fachada unificada) y crea el esqueleto de `toolsMCPAPI`, la fachada delgada del ADR-013, con una tool de prueba de punta a punta (`man_get_equipos`).

## Por qué
Primer paso de la unificación MCP (ADR-013): antes de migrar todas las tools a la fachada, había que confirmar en la práctica una asunción de la decisión #6 del ADR (que el relevamiento no había confirmado en vivo). Con eso confirmado, se deja el patrón base (`toolsMCPAPI` + una tool real) listo para que la Tarea 3.2 migre el resto de mantenimiento.

## Cómo lo verifiqué
- **PASO 1 (verificación obligatoria):** evidencia estática directa — `toolsMANAPI.xml` ya rutea distintos resources a `MANDataService` y `MANEquiposDataService` (dos DataServices distintos) con el mismo mecanismo dinámico de construcción de URL, ya verificado en producción (`doc/mcp/virtual-mcp-equipos.md` dice "Configurado y verificado en APIM 4.6.0").
- Además, intenté una verificación en vivo real usando el MI local de Rodolfo (`~/.wso2-mi/micro-integrator/wso2mi-4.5.0`, con JDK 17 vía sdkman): buildeé el `.car` (`./mvnw clean install`, confirmé que `toolsMCPAPI` queda empaquetado junto a `toolsMANAPI`), lo deployé y arranqué el MI. El servidor levantó bien (22.8s), pero el CAR completo falló al deployar por un `SocketTimeoutException` de `ALMDataService` intentando conectar a PostgreSQL (sin ruta de red desde este entorno a esa BD) — **no relacionado a `toolsMCPAPI`**, confirma que el deploy del CApp es atómico. Dejé el MI como lo encontré (detenido) al terminar.
- Build verificado limpio con `./mvnw clean install` (sin errores nuevos atribuibles a mi cambio; los ERROR de `querysServicios.sql`/`dnato-public-key.pem` son preexistentes y no bloquean el build).
- Sintaxis XML validada (`python3 -m xml.dom.minidom`).
- Tests Hurl escritos (`tests/security/mcp-facade-man-get-equipos.hurl`) siguiendo el patrón de `mi-fallback.hurl` — no pude correrlos en este entorno (sin `hurl` instalado y sin conectividad a la BD real), quedan listos para correr en un entorno con ambas cosas.

No mergear — review de Rodolfo.