### PR TITLE
feat(mcp): migrar las 5 tools de mantenimiento a toolsMCPAPI [E2-MCP-12]

### DIFF
--- a/_backend/api/ToolsAPIProject/ToolsAPIProject/src/main/wso2mi/artifacts/apis/toolsMCPAPI.xml
+++ b/_backend/api/ToolsAPIProject/ToolsAPIProject/src/main/wso2mi/artifacts/apis/toolsMCPAPI.xml
@@ -81,4 +81,370 @@
       </faultSequence>
    </resource>
 
+   <!-- ══════════════════════════════════════════════════════════════
+        E2-MCP-12 (ADR-013): resto de las tools de mantenimiento.
+        Cada resource de acá abajo es réplica 1:1 de su equivalente en
+        toolsMANAPI.xml — mismo DataService, misma query, mismo flujo.
+        Solo cambia la ruta (prefijo /mcp/man/...) y las etiquetas de log
+        (toolsMCPAPI en vez de toolsMANAPI). Sin lógica nueva.
+   ══════════════════════════════════════════════════════════════ -->
+
+   <!-- man_get_equipo — detalle de un equipo. Réplica de GET /mcp/equipo/{equi_id}
+        de toolsMANAPI. DataService: MANDataService.getEquipoIsolated. -->
+   <resource methods="GET" uri-template="/mcp/man/equipo/{equi_id}">
+      <inSequence>
+         <sequence key="emprIdFromHeader"/>
+
+         <property xmlns:ns2="http://org.apache.synapse/xsd" xmlns:ns="http://org.apache.synapse/xsd"
+                   name="apiconf"
+                   expression="get-property('registry','conf:tools/apiconfig.xml')"
+                   scope="default" type="OM"/>
+         <property xmlns:ns2="http://org.apache.synapse/xsd" xmlns:ns="http://org.apache.synapse/xsd"
+                   name="dataservices_url"
+                   expression="$ctx:apiconf//dataservices_url"/>
+
+         <!-- usa jwt_mysql_empresa_id (id nativo assetv2) — nunca el empr_id de Postgres -->
+         <property name="uri.var.getEquipo_url"
+                   expression="fn:concat($ctx:dataservices_url,'/MANDataService/mcp/equipo/',get-property('jwt_mysql_empresa_id'),'/',get-property('uri.var.equi_id'))"/>
+
+         <log level="custom" category="DEBUG">
+            <property name="text"              value="#TRAZA | MCP | man_get_equipo | iniciando (toolsMCPAPI)"/>
+            <property name="equi_id"           expression="get-property('uri.var.equi_id')"/>
+            <property name="mysql_empresa_id"  expression="get-property('jwt_mysql_empresa_id')"/>
+            <property name="url"               expression="$ctx:uri.var.getEquipo_url"/>
+         </log>
+
+         <header name="Accept" scope="transport" value="application/json"/>
+         <property name="messageType" scope="axis2" action="remove"/>
+         <property name="ContentType" scope="axis2" action="remove"/>
+         <header name="Content-Type" scope="transport" action="remove"/>
+         <property name="FORCE_ERROR_ON_SOAP_FAULT" value="true" scope="default" type="STRING"/>
+
+         <call>
+            <endpoint>
+               <http method="GET" uri-template="{uri.var.getEquipo_url}"/>
+            </endpoint>
+         </call>
+
+         <filter source="get-property('axis2', 'HTTP_SC')" regex="2[0-9][0-9]">
+            <then>
+               <respond/>
+            </then>
+            <else>
+               <property name="ERROR_MESSAGE" expression="json-eval($)" type="STRING"/>
+               <property name="TOOLS_ERROR" value="GET /mcp/man/equipo - MANDataService error" type="STRING"/>
+               <sequence key="toolsFault"/>
+            </else>
+         </filter>
+      </inSequence>
+      <faultSequence>
+         <property name="ERROR_MESSAGE" expression="json-eval($)" type="STRING"/>
+         <property name="TOOLS_ERROR" value="Error en MCP man_get_equipo (toolsMCPAPI)" type="STRING"/>
+         <sequence key="toolsFault"/>
+      </faultSequence>
+   </resource>
+
+   <!-- man_create_ot — crea una OT correctiva. Réplica de POST /mcp/ot de
+        toolsMANAPI: INSERT solicitud → GET id → POST BPM → PUT case_id,
+        con rollback (DELETE solicitud [+ DELETE instancia BPM]) si algún
+        paso falla (ADR-003, Opción A). NO reimplementa el flujo — mismo
+        DataService, mismo proceso Bonita, mismo mecanismo de rollback. -->
+   <resource methods="POST" uri-template="/mcp/man/ot">
+      <inSequence>
+         <sequence key="emprIdFromHeader"/>
+
+         <property xmlns:ns2="http://org.apache.synapse/xsd" xmlns:ns="http://org.apache.synapse/xsd"
+                   name="apiconf"
+                   expression="get-property('registry','conf:tools/apiconfig.xml')"
+                   scope="default" type="OM"/>
+         <property xmlns:ns2="http://org.apache.synapse/xsd" xmlns:ns="http://org.apache.synapse/xsd"
+                   name="api_url" expression="$ctx:apiconf//api_url"/>
+         <property xmlns:ns2="http://org.apache.synapse/xsd" xmlns:ns="http://org.apache.synapse/xsd"
+                   name="dataservices_url" expression="$ctx:apiconf//dataservices_url"/>
+
+         <property name="equipo_id"  expression="json-eval($.equipo_id)"/>
+         <property name="descripcion" expression="json-eval($.descripcion)"/>
+
+         <!-- f_solicitado: timestamp servidor -->
+         <script language="js"><![CDATA[
+            var sdf = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+            mc.setProperty("f_solicitado", sdf.format(new java.util.Date()));
+         ]]></script>
+
+         <log level="custom" category="DEBUG">
+            <property name="text"      value="#TRAZA | MCP | man_create_ot | iniciando (toolsMCPAPI)"/>
+            <property name="equipo_id" expression="get-property('equipo_id')"/>
+            <property name="empr_id"   expression="get-property('jwt_mysql_empresa_id')"/>
+         </log>
+
+         <!-- Paso 1: INSERT solicitud_reparacion -->
+         <payloadFactory media-type="json">
+            <format>{"solicitudRepracion":{"f_solicitado":"$1","id_equipo":"$2","estado":"S","usrId":"0","solicitante":"mcp-agent","causa":"$3","foto":"","id_empresa":"$4"}}</format>
+            <args>
+               <arg evaluator="xml" expression="get-property('f_solicitado')"/>
+               <arg evaluator="xml" expression="get-property('equipo_id')"/>
+               <arg evaluator="xml" expression="get-property('descripcion')"/>
+               <arg evaluator="xml" expression="get-property('jwt_mysql_empresa_id')"/>
+            </args>
+         </payloadFactory>
+         <header name="Accept" scope="transport" value="application/json"/>
+         <property name="messageType" value="application/json" scope="axis2"/>
+         <property name="FORCE_ERROR_ON_SOAP_FAULT" value="true" scope="default" type="STRING"/>
+         <property name="uri.var.solicitud_url"
+                   expression="fn:concat($ctx:dataservices_url,'/MANDataService/solicitudServicio')"/>
+         <call>
+            <endpoint>
+               <http method="POST" uri-template="{uri.var.solicitud_url}"/>
+            </endpoint>
+         </call>
+         <filter source="get-property('axis2', 'HTTP_SC')" regex="2[0-9][0-9]">
+            <then/>
+            <else>
+               <property name="ERROR_MESSAGE" expression="json-eval($)" type="STRING"/>
+               <property name="TOOLS_ERROR" value="POST /mcp/man/ot - INSERT solicitud failed" type="STRING"/>
+               <sequence key="toolsFault"/>
+            </else>
+         </filter>
+
+         <!-- Paso 2: GET id de la solicitud recién creada -->
+         <header name="Accept" scope="transport" value="application/json"/>
+         <property name="messageType" scope="axis2" action="remove"/>
+         <property name="ContentType" scope="axis2" action="remove"/>
+         <header name="Content-Type" scope="transport" action="remove"/>
+         <property name="FORCE_ERROR_ON_SOAP_FAULT" value="true" scope="default" type="STRING"/>
+         <property name="uri.var.ultimaSolicitud_url"
+                   expression="fn:concat($ctx:dataservices_url,'/MANDataService/solicitudServicio/ultima/',get-property('equipo_id'))"/>
+         <call>
+            <endpoint>
+               <http method="GET" uri-template="{uri.var.ultimaSolicitud_url}"/>
+            </endpoint>
+         </call>
+         <filter source="get-property('axis2', 'HTTP_SC')" regex="2[0-9][0-9]">
+            <then/>
+            <else>
+               <property name="ERROR_MESSAGE" expression="json-eval($)" type="STRING"/>
+               <property name="TOOLS_ERROR" value="POST /mcp/man/ot - GET ultima solicitud failed" type="STRING"/>
+               <sequence key="toolsFault"/>
+            </else>
+         </filter>
+         <property name="sose_id" expression="json-eval($.resultado.sose_id)"/>
+
+         <!-- Paso 3: POST BPM — instanciar proceso.
+              Session vacía: bpmAPICallTemplate hace auto-login en 401. -->
+         <payloadFactory media-type="json">
+            <format>{"nombre_proceso":"Proceso de Mantenimiento AssetPlanner SIM","payload":{"idSolicitudServicio":"$1","idOT":"0"},"session":"","emprId":"$2"}</format>
+            <args>
+               <arg evaluator="xml" expression="get-property('sose_id')"/>
+               <arg evaluator="xml" expression="get-property('jwt_mysql_empresa_id')"/>
+            </args>
+         </payloadFactory>
+         <header name="Accept" scope="transport" value="application/json"/>
+         <property name="FORCE_ERROR_ON_SOAP_FAULT" value="true" scope="default" type="STRING"/>
+         <property name="uri.var.bpm_url"
+                   expression="fn:concat($ctx:api_url,'/bpm/proceso/instancia')"/>
+         <call>
+            <endpoint>
+               <http method="POST" uri-template="{uri.var.bpm_url}"/>
+            </endpoint>
+         </call>
+         <filter source="get-property('axis2', 'HTTP_SC')" regex="2[0-9][0-9]">
+            <then/>
+            <else>
+               <!-- Rollback Opción A: DELETE solicitud si BPM falla -->
+               <payloadFactory media-type="json">
+                  <format>{"_delete_solicitudServicio":{"soco_id":"$1"}}</format>
+                  <args>
+                     <arg evaluator="xml" expression="get-property('sose_id')"/>
+                  </args>
+               </payloadFactory>
+               <property name="uri.var.deleteSolicitud_url"
+                         expression="fn:concat($ctx:dataservices_url,'/MANDataService/solicitudServicio')"/>
+               <call>
+                  <endpoint>
+                     <http method="DELETE" uri-template="{uri.var.deleteSolicitud_url}"/>
+                  </endpoint>
+               </call>
+               <property name="ERROR_MESSAGE" expression="json-eval($)" type="STRING"/>
+               <property name="TOOLS_ERROR" value="POST /mcp/man/ot - BPM failed, solicitud rolled back" type="STRING"/>
+               <sequence key="toolsFault"/>
+            </else>
+         </filter>
+         <property name="case_id" expression="json-eval($.payload.caseId)" type="STRING"/>
+
+         <!-- Paso 4: PUT case_id en solicitud -->
+         <payloadFactory media-type="json">
+            <format>{"_put_solicitudServicio_caseid":{"case_id":"$1","sose_id":"$2"}}</format>
+            <args>
+               <arg evaluator="xml" expression="get-property('case_id')"/>
+               <arg evaluator="xml" expression="get-property('sose_id')"/>
+            </args>
+         </payloadFactory>
+         <header name="Accept" scope="transport" value="application/json"/>
+         <property name="FORCE_ERROR_ON_SOAP_FAULT" value="true" scope="default" type="STRING"/>
+         <property name="uri.var.caseId_url"
+                   expression="fn:concat($ctx:dataservices_url,'/MANDataService/solicitudServicio/caseid')"/>
+         <call>
+            <endpoint>
+               <http method="PUT" uri-template="{uri.var.caseId_url}"/>
+            </endpoint>
+         </call>
+         <filter source="get-property('axis2', 'HTTP_SC')" regex="2[0-9][0-9]">
+            <then/>
+            <else>
+               <!-- Rollback Opción A: DELETE solicitud + DELETE instancia BPM -->
+               <payloadFactory media-type="json">
+                  <format>{"_delete_solicitudServicio":{"soco_id":"$1"}}</format>
+                  <args>
+                     <arg evaluator="xml" expression="get-property('sose_id')"/>
+                  </args>
+               </payloadFactory>
+               <property name="uri.var.deleteSolicitud_url"
+                         expression="fn:concat($ctx:dataservices_url,'/MANDataService/solicitudServicio')"/>
+               <call>
+                  <endpoint>
+                     <http method="DELETE" uri-template="{uri.var.deleteSolicitud_url}"/>
+                  </endpoint>
+               </call>
+               <property name="uri.var.deleteBPM_url"
+                         expression="fn:concat($ctx:api_url,'/bpm/proceso/instancia/')"/>
+               <call>
+                  <endpoint>
+                     <http method="DELETE" uri-template="{uri.var.deleteBPM_url}"/>
+                  </endpoint>
+               </call>
+               <property name="ERROR_MESSAGE" expression="json-eval($)" type="STRING"/>
+               <property name="TOOLS_ERROR" value="POST /mcp/man/ot - caseid update failed, solicitud and BPM rolled back" type="STRING"/>
+               <sequence key="toolsFault"/>
+            </else>
+         </filter>
+
+         <loopback/>
+      </inSequence>
+      <outSequence>
+         <payloadFactory media-type="json">
+            <format>{"resultado":"ok","ot_id":"$1","case_id":"$2","estado":"S"}</format>
+            <args>
+               <arg evaluator="xml" expression="get-property('sose_id')"/>
+               <arg evaluator="xml" expression="get-property('case_id')"/>
+            </args>
+         </payloadFactory>
+         <send/>
+      </outSequence>
+      <faultSequence>
+         <property name="ERROR_MESSAGE" expression="json-eval($)" type="STRING"/>
+         <property name="TOOLS_ERROR" value="Error general en MCP man_create_ot (toolsMCPAPI)" type="STRING"/>
+         <sequence key="toolsFault"/>
+      </faultSequence>
+   </resource>
+
+   <!-- man_get_ots — lista de OTs de la empresa del JWT. Réplica de GET /mcp/ot
+        de toolsMANAPI. Param ?estado= opcional (sin estado: todo excepto AN). -->
+   <resource methods="GET" uri-template="/mcp/man/ot">
+      <inSequence>
+         <sequence key="emprIdFromHeader"/>
+
+         <property xmlns:ns2="http://org.apache.synapse/xsd" xmlns:ns="http://org.apache.synapse/xsd"
+                   name="apiconf"
+                   expression="get-property('registry','conf:tools/apiconfig.xml')"
+                   scope="default" type="OM"/>
+         <property xmlns:ns2="http://org.apache.synapse/xsd" xmlns:ns="http://org.apache.synapse/xsd"
+                   name="dataservices_url" expression="$ctx:apiconf//dataservices_url"/>
+
+         <!-- Leer ?estado= del request entrante; vacío si no viene -->
+         <property name="ot_estado_filter"
+                   expression="get-property('query.param.estado')"
+                   scope="default" type="STRING"/>
+         <filter xpath="not(boolean(get-property('ot_estado_filter')))">
+            <then>
+               <property name="ot_estado_filter" value="" scope="default" type="STRING"/>
+            </then>
+         </filter>
+
+         <property name="uri.var.listaOTs_url"
+                   expression="fn:concat($ctx:dataservices_url,'/MANDataService/mcp/ots/',get-property('jwt_mysql_empresa_id'),'?estado=',get-property('ot_estado_filter'))"/>
+
+         <log level="custom" category="DEBUG">
+            <property name="text"    value="#TRAZA | MCP | man_get_ots | lista (toolsMCPAPI)"/>
+            <property name="empr_id" expression="get-property('jwt_mysql_empresa_id')"/>
+            <property name="estado"  expression="get-property('ot_estado_filter')"/>
+         </log>
+
+         <header name="Accept" scope="transport" value="application/json"/>
+         <property name="messageType" scope="axis2" action="remove"/>
+         <property name="ContentType" scope="axis2" action="remove"/>
+         <header name="Content-Type" scope="transport" action="remove"/>
+         <property name="FORCE_ERROR_ON_SOAP_FAULT" value="true" scope="default" type="STRING"/>
+         <call>
+            <endpoint>
+               <http method="GET" uri-template="{uri.var.listaOTs_url}"/>
+            </endpoint>
+         </call>
+         <filter source="get-property('axis2', 'HTTP_SC')" regex="2[0-9][0-9]">
+            <then>
+               <respond/>
+            </then>
+            <else>
+               <property name="ERROR_MESSAGE" expression="json-eval($)" type="STRING"/>
+               <property name="TOOLS_ERROR" value="GET /mcp/man/ot - MANDataService error" type="STRING"/>
+               <sequence key="toolsFault"/>
+            </else>
+         </filter>
+      </inSequence>
+      <faultSequence>
+         <property name="ERROR_MESSAGE" expression="json-eval($)" type="STRING"/>
+         <property name="TOOLS_ERROR" value="Error en MCP man_get_ots (toolsMCPAPI)" type="STRING"/>
+         <sequence key="toolsFault"/>
+      </faultSequence>
+   </resource>
+
+   <!-- man_get_ot — detalle de OT filtrado por empresa del JWT. Réplica de
+        GET /mcp/ot/{id_solicitud} de toolsMANAPI. -->
+   <resource methods="GET" uri-template="/mcp/man/ot/{id_solicitud}">
+      <inSequence>
+         <sequence key="emprIdFromHeader"/>
+
+         <property xmlns:ns2="http://org.apache.synapse/xsd" xmlns:ns="http://org.apache.synapse/xsd"
+                   name="apiconf"
+                   expression="get-property('registry','conf:tools/apiconfig.xml')"
+                   scope="default" type="OM"/>
+         <property xmlns:ns2="http://org.apache.synapse/xsd" xmlns:ns="http://org.apache.synapse/xsd"
+                   name="dataservices_url" expression="$ctx:apiconf//dataservices_url"/>
+
+         <property name="uri.var.detalleOT_url"
+                   expression="fn:concat($ctx:dataservices_url,'/MANDataService/mcp/ot/',get-property('jwt_mysql_empresa_id'),'/',get-property('uri.var.id_solicitud'))"/>
+
+         <log level="custom" category="DEBUG">
+            <property name="text"         value="#TRAZA | MCP | man_get_ot | detalle (toolsMCPAPI)"/>
+            <property name="id_solicitud" expression="get-property('uri.var.id_solicitud')"/>
+            <property name="empr_id"      expression="get-property('jwt_mysql_empresa_id')"/>
+         </log>
+
+         <header name="Accept" scope="transport" value="application/json"/>
+         <property name="messageType" scope="axis2" action="remove"/>
+         <property name="ContentType" scope="axis2" action="remove"/>
+         <header name="Content-Type" scope="transport" action="remove"/>
+         <property name="FORCE_ERROR_ON_SOAP_FAULT" value="true" scope="default" type="STRING"/>
+         <call>
+            <endpoint>
+               <http method="GET" uri-template="{uri.var.detalleOT_url}"/>
+            </endpoint>
+         </call>
+         <filter source="get-property('axis2', 'HTTP_SC')" regex="2[0-9][0-9]">
+            <then>
+               <respond/>
+            </then>
+            <else>
+               <property name="ERROR_MESSAGE" expression="json-eval($)" type="STRING"/>
+               <property name="TOOLS_ERROR" value="GET /mcp/man/ot/{id} - MANDataService error" type="STRING"/>
+               <sequence key="toolsFault"/>
+            </else>
+         </filter>
+      </inSequence>
+      <faultSequence>
+         <property name="ERROR_MESSAGE" expression="json-eval($)" type="STRING"/>
+         <property name="TOOLS_ERROR" value="Error en MCP man_get_ot detalle (toolsMCPAPI)" type="STRING"/>
+         <sequence key="toolsFault"/>
+      </faultSequence>
+   </resource>
+
 </api>

--- a/doc/v3/STATE.md
+++ b/doc/v3/STATE.md
@@ -14,14 +14,15 @@
 
 **Sprint actual:** Sprint 3 — Activación early adopter minero
 **Objetivo del sprint:** Reemplazar ngrok por un despliegue estable en GCP (ADR-011) y cerrar la deuda técnica pendiente antes de activar al primer cliente early adopter.
-**Última actualización:** 2026-07-31 por Claude Code (E2-MCP-11)
+**Última actualización:** 2026-07-31 por Claude Code (E2-MCP-12)
 
 ### Tareas activas
 
 | ID | Descripción | Clase | Estado | Rama / PR |
 |---|---|---|---|---|
-| E2-MCP-11 | Verificar ruteo múltiple + esqueleto de la fachada `toolsMCPAPI` (Bloque 3, tarea 3.1) | 🔴 | **Completada** — ruteo múltiple confirmado, `toolsMCPAPI` creado con `man_get_equipos` end-to-end | `feature/e2-mcp-11-toolsmcpapi-skeleton` — PR abierto, sin mergear |
-| ADR-013 | Unificación MCP: fachada delgada `toolsMCPAPI`, un solo Virtual MCP Server | — | **Aprobado y mergeado** (workshop CW+Rodolfo sobre el relevamiento) | PR #408, `sprint-3-prompts.md` actualizado en PR #409 |
+| E2-MCP-12 | Migrar las 5 tools de mantenimiento a `toolsMCPAPI` (Bloque 3, tarea 3.2) | 🟡 | **Completada** — las 5 tools (`man_get_equipos`, `man_get_equipo`, `man_get_ots`, `man_get_ot`, `man_create_ot`) en `toolsMCPAPI`, ninguna reimplementa lógica | `feature/e2-mcp-12-toolsmcpapi-mantenimiento` — PR abierto, sin mergear |
+| E2-MCP-11 | Verificar ruteo múltiple + esqueleto de la fachada `toolsMCPAPI` (Bloque 3, tarea 3.1) | 🔴 | Completada y mergeada | PR #410 |
+| ADR-013 | Unificación MCP: fachada delgada `toolsMCPAPI`, un solo Virtual MCP Server | — | Aprobado y mergeado | PR #408, `sprint-3-prompts.md` en PR #409 |
 | E2-MCP-10-RELEV | Relevamiento para unificación de Virtual MCP Servers (Bloque 0) | 🟢 | Completada y mergeada | PR #407 |
 | E7-INFRA-01/02 | Sizing VM GCP + scripts instalación nativa WSO2 (ADR-011) | 🟡 | Completada y mergeada — VM funcionando end-to-end | PR #403 y #404 mergeados |
 | ADR-012 | Aislamiento y alcance de Almacenes | — | Aprobado y mergeado | PR #405 |
@@ -29,22 +30,22 @@
 
 ### Próxima acción
 
-Tarea 3.1 del Bloque 3 completada: el ruteo a múltiples DataServices desde una sola API MI está confirmado (ver decisión de hoy), y `toolsMCPAPI` existe con una tool de punta a punta (`man_get_equipos`) siguiendo el patrón exacto de `toolsMANAPI`. **Próximo paso, en orden estricto (ADR-013): Tarea 3.2** — migrar el resto de las tools de mantenimiento (`man_get_equipo`, `man_get_ots`, `man_get_ot`, `man_create_ot`) a `toolsMCPAPI`, una vez que este PR se revise y mergee. En paralelo siguen pendientes: Bloque 1 (abrir PR de `docs/e1-api-20-sprint3-relevamiento-estado`), Bloque 2 (E7-INFRA-03, identidad en la VM nueva), y que Rodolfo responda las preguntas abiertas de `doc/v3/sprint-3-relevamiento-estado.md`.
+Tarea 3.2 del Bloque 3 completada: `toolsMCPAPI` tiene ahora las 5 tools de mantenimiento (`man_get_equipos`, `man_get_equipo`, `man_get_ots`, `man_get_ot`, `man_create_ot`), cada una réplica 1:1 del recurso equivalente en `toolsMANAPI` — mismo DataService, mismo proceso BPM+rollback en `man_create_ot`, sin lógica nueva. **Próximo paso, en orden estricto (ADR-013): Tarea 3.3** — sumar las tools de almacenes (`alm_*`) a la fachada, una vez que este PR se revise y mergee. Es clase 🔴 con puntos de parada obligatoria (proceso Bonita de pedidos, payload real, análogo de `ALMDataService`). En paralelo siguen pendientes: Bloque 1, Bloque 2 (E7-INFRA-03), y las preguntas abiertas de `doc/v3/sprint-3-relevamiento-estado.md`.
 
 ### Decisiones recientes (últimas 5)
 
 | Fecha | Decisión | Referencia |
 |---|---|---|
-| 2026-07-31 | **E2-MCP-11 — ruteo múltiple CONFIRMADO.** Evidencia estática sólida: `toolsMANAPI` ya rutea distintos resources a distintos DataServices (`MANDataService`, `MANEquiposDataService`) con el mismo mecanismo dinámico (`fn:concat($ctx:dataservices_url,'/<DataService>/...')`), ya verificado en producción. Se intentó además una verificación en vivo real (MI local de Rodolfo, `.car` recién buildeado con `toolsMCPAPI`) — el MI arrancó bien, pero el CAR completo falló al deployar por un timeout de conexión de `ALMDataService` a PostgreSQL (sin ruta de red desde este entorno a esa BD) — **no relacionado a `toolsMCPAPI` ni a la pregunta de ruteo**, solo evidencia que el deploy del CApp es atómico (una falla de conexión de cualquier DataService revierte todo el CAR). `toolsMCPAPI` creado con `man_get_equipos` (réplica exacta de `/mcp/equipos` de `toolsMANAPI`, bajo `/mcp/man/equipos`) | `_backend/api/ToolsAPIProject/.../artifacts/apis/toolsMCPAPI.xml`, ADR-013 |
-| 2026-07-31 | ADR-013 aprobado y mergeado: fachada delgada `toolsMCPAPI` (resuelve empr_id una vez, rutea a DataServices existentes), un solo Virtual MCP Server, tools con prefijo de módulo (`man_`, `alm_`) | PR #408, `doc/adr/ADR-013-unificacion-mcp.md` |
-| 2026-07-31 | Relevamiento de unificación MCP completado: 1 API WSO2 = 1 Virtual MCP Server (no se pueden combinar varias APIs), confirmado contra doc oficial 4.6.0 + evidencia del propio entorno | PR #407, `doc/v3/relevamiento-unificacion-mcp.md` |
-| 2026-07-30 | ADR-012 aprobado y mergeado: Almacenes reusa el patrón de Mantenimiento (empr_id del JWT, crear_pedido_materiales con BPM+rollback estilo create_ot), alcance limitado a pedidos (sin operaciones de stock) | PR #405, `doc/adr/ADR-012-almacenes-aislamiento.md` |
-| 2026-07-28 | E7-INFRA-01/02 completada en la práctica: VM levantada, APIM+MI corriendo. SELinux + repo JDK corregidos | PR #404, `doc/v3/deployment-gcp.md`, ADR-011 |
+| 2026-07-31 | **E2-MCP-12 completada.** Las 5 tools de mantenimiento migradas a `toolsMCPAPI` con prefijo `man_`, rutas `/mcp/man/...`. `man_create_ot` conserva el flujo INSERT→BPM→PUT case_id con rollback (ADR-003 Opción A) sin reimplementarlo — mismo DataService (`MANDataService`), mismo proceso Bonita. Build (`./mvnw clean install`) verificado, `.car` genera `toolsMCPAPI-1.0.0.xml` con las 5 resources. Tests Hurl agregados para las 4 tools nuevas (contrato de identidad fail-closed) | `_backend/api/ToolsAPIProject/.../artifacts/apis/toolsMCPAPI.xml`, `tests/security/mcp-facade-man-tools.hurl` |
+| 2026-07-31 | E2-MCP-11 mergeado (PR #410): ruteo múltiple a distintos DataServices desde una sola API MI confirmado (evidencia estática + confirmación de Rodolfo por experiencia propia) | PR #410 |
+| 2026-07-31 | ADR-013 aprobado y mergeado: fachada delgada `toolsMCPAPI`, un solo Virtual MCP Server, tools con prefijo de módulo (`man_`, `alm_`) | PR #408, `doc/adr/ADR-013-unificacion-mcp.md` |
+| 2026-07-31 | Relevamiento de unificación MCP completado: 1 API WSO2 = 1 Virtual MCP Server (no se pueden combinar varias APIs) | PR #407, `doc/v3/relevamiento-unificacion-mcp.md` |
+| 2026-07-30 | ADR-012 aprobado y mergeado: Almacenes reusa el patrón de Mantenimiento, alcance limitado a pedidos (sin operaciones de stock) | PR #405, `doc/adr/ADR-012-almacenes-aislamiento.md` |
 
 ### Bloqueos
 
-- **Tarea 3.3 (Almacenes en la fachada) espera que 3.1 (esta) y 3.2 se mergeen primero** — orden estricto de ADR-013.
-- Config de identidad (ADR-008/009) y migración de DataServices a PostgreSQL siguen pendientes antes de poder dar de alta al primer cliente sobre la VM de GCP — cubierto por E7-INFRA-03 (Bloque 2 de `sprint-3-prompts.md`, no ejecutado todavía).
-- **Nota operativa para cuando se pruebe end-to-end con BD real:** el deploy del `.car` de `ToolsAPIProject` es atómico — si `ALMDataService` (o cualquier otro `.dbs` del proyecto) no puede conectar a su BD al momento del deploy, se revierte el CAR completo, incluida `toolsMCPAPI`. No es un problema de esta tarea, pero vale tenerlo presente para la VM de GCP y para cuando se sumen las DataServices de almacenes (Tarea 3.3).
+- **Tarea 3.3 (Almacenes en la fachada) espera que esta tarea (3.2) se mergee primero** — orden estricto de ADR-013. Es clase 🔴, con puntos de parada obligatoria ya anticipados en `sprint-3-prompts.md`.
+- Config de identidad (ADR-008/009) y migración de DataServices a PostgreSQL siguen pendientes antes de poder dar de alta al primer cliente sobre la VM de GCP — cubierto por E7-INFRA-03 (Bloque 2, no ejecutado todavía).
+- **Nota operativa (de E2-MCP-11, sigue vigente):** el deploy del `.car` de `ToolsAPIProject` es atómico — si `ALMDataService` (o cualquier otro `.dbs`) no puede conectar a su BD al momento del deploy, se revierte el CAR completo. Relevante para cuando se sumen las DataServices de almacenes (Tarea 3.3) y para el deploy en la VM de GCP.
 - La implementación de escritura MCP en Almacenes sigue bloqueada hasta que el PM confirme cómo resolver el aislamiento multi-tenant de `ALMDataService` (ver pregunta abierta #1 del relevamiento de Sprint 3) — posible tema de arquitectura (🔴).
 

--- a/tests/security/mcp-facade-man-tools.hurl
+++ b/tests/security/mcp-facade-man-tools.hurl
@@ -1,0 +1,107 @@
+# E2-MCP-12 (ADR-013) — Tests de las tools de mantenimiento en toolsMCPAPI
+# (man_get_equipo, man_get_ots, man_get_ot, man_create_ot)
+#
+# Mismo patrón que mcp-facade-man-get-equipos.hurl (E2-MCP-11): llama al MI
+# DIRECTAMENTE (:8290), simulando X-JWT-Assertion con
+# scripts/dev/mint-backend-jwt.py. Cubre el contrato de identidad
+# (fail-closed sin empr_id) para las 4 tools nuevas — el smoke test
+# funcional completo (con BD y BPM reales) se hace en la migración
+# coordinada de la Tarea 3.4.
+#
+# Pre-requisitos:
+#   1. MI corriendo con el CAR de ToolsAPIProject actualizado (toolsMCPAPI
+#      con las 5 tools de mantenimiento) deployado
+#   2. Para los Casos C (respuesta real, no solo "no 503"): conectividad a
+#      la BD de MANDataService/MANEquiposDataService y, para man_create_ot,
+#      a Bonita BPM
+#
+# Variables requeridas:
+#   MI_HOST         = host:port del MI (ej: localhost:8290)
+#   VALID_ASSERTION = generar con: python3 scripts/dev/mint-backend-jwt.py 42 42
+#
+# Ejecutar:
+#   ASSERTION=$(python3 scripts/dev/mint-backend-jwt.py 42 42)
+#   hurl --variable MI_HOST=localhost:8290 --variable VALID_ASSERTION="$ASSERTION" \
+#        mcp-facade-man-tools.hurl
+
+
+# ─────────────────────────────────────────────────────────────────
+# man_get_equipo — GET /tools/mcp/mcp/man/equipo/{equi_id}
+# ─────────────────────────────────────────────────────────────────
+
+# Caso A: sin X-JWT-Assertion → 503 identity_missing
+GET http://{{MI_HOST}}/tools/mcp/mcp/man/equipo/10
+HTTP 503
+[Asserts]
+jsonpath "$.error" == "identity_missing"
+
+# Caso C: X-JWT-Assertion válido → NO 503 (empr_id resuelto, ruteó a MANDataService)
+GET http://{{MI_HOST}}/tools/mcp/mcp/man/equipo/10
+X-JWT-Assertion: {{VALID_ASSERTION}}
+HTTP *
+[Asserts]
+status != 503
+
+
+# ─────────────────────────────────────────────────────────────────
+# man_get_ots — GET /tools/mcp/mcp/man/ot
+# ─────────────────────────────────────────────────────────────────
+
+# Caso A: sin X-JWT-Assertion → 503 identity_missing
+GET http://{{MI_HOST}}/tools/mcp/mcp/man/ot
+HTTP 503
+[Asserts]
+jsonpath "$.error" == "identity_missing"
+
+# Caso C: X-JWT-Assertion válido → NO 503
+GET http://{{MI_HOST}}/tools/mcp/mcp/man/ot
+X-JWT-Assertion: {{VALID_ASSERTION}}
+HTTP *
+[Asserts]
+status != 503
+
+
+# ─────────────────────────────────────────────────────────────────
+# man_get_ot — GET /tools/mcp/mcp/man/ot/{id_solicitud}
+# ─────────────────────────────────────────────────────────────────
+
+# Caso A: sin X-JWT-Assertion → 503 identity_missing
+GET http://{{MI_HOST}}/tools/mcp/mcp/man/ot/1
+HTTP 503
+[Asserts]
+jsonpath "$.error" == "identity_missing"
+
+# Caso C: X-JWT-Assertion válido → NO 503
+GET http://{{MI_HOST}}/tools/mcp/mcp/man/ot/1
+X-JWT-Assertion: {{VALID_ASSERTION}}
+HTTP *
+[Asserts]
+status != 503
+
+
+# ─────────────────────────────────────────────────────────────────
+# man_create_ot — POST /tools/mcp/mcp/man/ot
+# El flujo completo (INSERT + BPM + rollback) requiere Bonita + BD reales
+# (ver ot-mcp.hurl para el smoke test funcional completo, vía APIM). Acá
+# solo se cubre el contrato de identidad de la fachada.
+# ─────────────────────────────────────────────────────────────────
+
+# Caso A: sin X-JWT-Assertion → 503 identity_missing (NO debe llegar a
+# insertar nada en MANDataService — el fail-closed corta antes del INSERT)
+POST http://{{MI_HOST}}/tools/mcp/mcp/man/ot
+Content-Type: application/json
+{ "equipo_id": "10", "descripcion": "test sin auth" }
+HTTP 503
+[Asserts]
+jsonpath "$.error" == "identity_missing"
+
+# Caso C: X-JWT-Assertion válido → NO 503 (empr_id resuelto, arrancó el
+# flujo INSERT→BPM→PUT case_id; el resultado final depende de BD/Bonita
+# reales, no evaluados acá)
+POST http://{{MI_HOST}}/tools/mcp/mcp/man/ot
+X-JWT-Assertion: {{VALID_ASSERTION}}
+Content-Type: application/json
+{ "equipo_id": "10", "descripcion": "test con auth" }
+HTTP *
+[Asserts]
+status != 503


### PR DESCRIPTION
## Qué cambia
Tarea 3.2 del Bloque 3 (ADR-013). Suma a `toolsMCPAPI` las 4 tools de mantenimiento que faltaban (`man_get_equipo`, `man_get_ots`, `man_get_ot`, `man_create_ot`) — `man_get_equipos` ya estaba desde E2-MCP-11 (PR #410, mergeado). Las 5 tools de mantenimiento quedan disponibles en la fachada unificada.

## Por qué
Segundo paso de la unificación MCP (ADR-013), en el orden estricto definido: con el patrón validado en 3.1, se migra el resto de mantenimiento antes de sumar almacenes (3.3).

## Cómo lo verifiqué
- Cada resource nuevo es réplica 1:1 de su equivalente en `toolsMANAPI.xml` (mismo DataService, misma query, mismo flujo) — comparé línea por línea contra el original al escribirlo, no reimplementé nada. `man_create_ot` conserva exactamente el patrón INSERT→BPM→PUT case_id con rollback (ADR-003 Opción A).
- Build verificado: `./mvnw clean install` sin errores nuevos (los ERROR de `querysServicios.sql`/`dnato-public-key.pem` son preexistentes, no relacionados a este cambio) — el `.car` empaqueta `toolsMCPAPI-1.0.0.xml` con las 5 resources.
- Sintaxis XML validada (`python3 -m xml.dom.minidom`).
- Tests Hurl agregados (`tests/security/mcp-facade-man-tools.hurl`) para el contrato de identidad (fail-closed) de las 4 tools nuevas — no pude correrlos en este entorno (sin `hurl` instalado, sin conectividad a BD/Bonita reales), quedan listos para correr en un entorno con ambos.

No mergear — review de Rodolfo.