### PR TITLE
docs: documentar parada obligatoria en tarea 3.3 (almacenes) [E1-ALM]

### DIFF
--- a/doc/v3/STATE.md
+++ b/doc/v3/STATE.md
@@ -14,13 +14,14 @@
 
 **Sprint actual:** Sprint 3 — Activación early adopter minero
 **Objetivo del sprint:** Reemplazar ngrok por un despliegue estable en GCP (ADR-011) y cerrar la deuda técnica pendiente antes de activar al primer cliente early adopter.
-**Última actualización:** 2026-07-31 por Claude Code (E2-MCP-12)
+**Última actualización:** 2026-07-31 por Claude Code (E1-ALM / tarea 3.3 — DETENIDA)
 
 ### Tareas activas
 
 | ID | Descripción | Clase | Estado | Rama / PR |
 |---|---|---|---|---|
-| E2-MCP-12 | Migrar las 5 tools de mantenimiento a `toolsMCPAPI` (Bloque 3, tarea 3.2) | 🟡 | **Completada** — las 5 tools (`man_get_equipos`, `man_get_equipo`, `man_get_ots`, `man_get_ot`, `man_create_ot`) en `toolsMCPAPI`, ninguna reimplementa lógica | `feature/e2-mcp-12-toolsmcpapi-mantenimiento` — PR abierto, sin mergear |
+| E1-ALM (3.3) | Sumar almacenes a `toolsMCPAPI` (Bloque 3, tarea 3.3) | 🔴 | **DETENIDA — parada obligatoria.** Relevado `ALMDataService` + PHP v2 real: el payload/proceso/flujo NO son análogos a `create_ot` como asumía ADR-012. Sin código escrito. Esperando decisión de Rodolfo (ver preguntas abiertas abajo) | Sin rama — no se abrió PR (nada que mostrar todavía) |
+| E2-MCP-12 | Migrar las 5 tools de mantenimiento a `toolsMCPAPI` (Bloque 3, tarea 3.2) | 🟡 | Completada y mergeada | PR #411 |
 | E2-MCP-11 | Verificar ruteo múltiple + esqueleto de la fachada `toolsMCPAPI` (Bloque 3, tarea 3.1) | 🔴 | Completada y mergeada | PR #410 |
 | ADR-013 | Unificación MCP: fachada delgada `toolsMCPAPI`, un solo Virtual MCP Server | — | Aprobado y mergeado | PR #408, `sprint-3-prompts.md` en PR #409 |
 | E2-MCP-10-RELEV | Relevamiento para unificación de Virtual MCP Servers (Bloque 0) | 🟢 | Completada y mergeada | PR #407 |
@@ -30,13 +31,14 @@
 
 ### Próxima acción
 
-Tarea 3.2 del Bloque 3 completada: `toolsMCPAPI` tiene ahora las 5 tools de mantenimiento (`man_get_equipos`, `man_get_equipo`, `man_get_ots`, `man_get_ot`, `man_create_ot`), cada una réplica 1:1 del recurso equivalente en `toolsMANAPI` — mismo DataService, mismo proceso BPM+rollback en `man_create_ot`, sin lógica nueva. **Próximo paso, en orden estricto (ADR-013): Tarea 3.3** — sumar las tools de almacenes (`alm_*`) a la fachada, una vez que este PR se revise y mergee. Es clase 🔴 con puntos de parada obligatoria (proceso Bonita de pedidos, payload real, análogo de `ALMDataService`). En paralelo siguen pendientes: Bloque 1, Bloque 2 (E7-INFRA-03), y las preguntas abiertas de `doc/v3/sprint-3-relevamiento-estado.md`.
+**Tarea 3.3 detenida en el PASO de relevamiento, antes de escribir código** (parada obligatoria 🔴, según lo previsto en `sprint-3-prompts.md`). Al relevar `ALMDataService.dbs` + el PHP v2 real que hoy crea pedidos de materiales (`application/modules/traz-comp-almacenes/models/new/Pedidosmateriales.php` y afines), aparecieron 3 discrepancias con lo que asumía ADR-012 — ver decisión de hoy. **Se necesita que Rodolfo responda antes de seguir**, ver preguntas abiertas en Bloqueos. En paralelo siguen pendientes: Bloque 1, Bloque 2 (E7-INFRA-03), y las preguntas abiertas de `doc/v3/sprint-3-relevamiento-estado.md`.
 
 ### Decisiones recientes (últimas 5)
 
 | Fecha | Decisión | Referencia |
 |---|---|---|
-| 2026-07-31 | **E2-MCP-12 completada.** Las 5 tools de mantenimiento migradas a `toolsMCPAPI` con prefijo `man_`, rutas `/mcp/man/...`. `man_create_ot` conserva el flujo INSERT→BPM→PUT case_id con rollback (ADR-003 Opción A) sin reimplementarlo — mismo DataService (`MANDataService`), mismo proceso Bonita. Build (`./mvnw clean install`) verificado, `.car` genera `toolsMCPAPI-1.0.0.xml` con las 5 resources. Tests Hurl agregados para las 4 tools nuevas (contrato de identidad fail-closed) | `_backend/api/ToolsAPIProject/.../artifacts/apis/toolsMCPAPI.xml`, `tests/security/mcp-facade-man-tools.hurl` |
+| 2026-07-31 | **Tarea 3.3 (almacenes) DETENIDA — parada obligatoria.** El PHP real (`Pedidosmateriales.php`, `models/new/`) muestra que "crear pedido" está atado a una OT (`ortr_id`, detalle sourced de `tbl_otinsumos`), no a un payload libre de artículo+cantidad+depósito como asumía ADR-012. El proceso Bonita se identifica por ID numérico (`BPM_PROCESS_ID_PEDIDOS_NORMALES` = `8803232493891311406`, no por nombre como `create_ot`). El PHP no hace rollback (DELETE) explícito si el BPM falla — a diferencia del patrón de `create_ot`. Además, en `ALMDataService.dbs` no existe una query de "listado de pedidos de la empresa" análoga a `mcp/ots`, y la query de stock más completa (`getStock`) exige también `id_user` (encargado de depósito), no solo `empr_id`. Ningún código escrito — se paró antes, tal como indica el prompt | (sin archivo nuevo — hallazgos documentados acá y en el chat con Rodolfo) |
+| 2026-07-31 | E2-MCP-12 completada y mergeada: las 5 tools de mantenimiento en `toolsMCPAPI` con prefijo `man_`, ninguna reimplementa lógica | PR #411, `_backend/api/ToolsAPIProject/.../artifacts/apis/toolsMCPAPI.xml` |
 | 2026-07-31 | E2-MCP-11 mergeado (PR #410): ruteo múltiple a distintos DataServices desde una sola API MI confirmado (evidencia estática + confirmación de Rodolfo por experiencia propia) | PR #410 |
 | 2026-07-31 | ADR-013 aprobado y mergeado: fachada delgada `toolsMCPAPI`, un solo Virtual MCP Server, tools con prefijo de módulo (`man_`, `alm_`) | PR #408, `doc/adr/ADR-013-unificacion-mcp.md` |
 | 2026-07-31 | Relevamiento de unificación MCP completado: 1 API WSO2 = 1 Virtual MCP Server (no se pueden combinar varias APIs) | PR #407, `doc/v3/relevamiento-unificacion-mcp.md` |
@@ -44,7 +46,12 @@ Tarea 3.2 del Bloque 3 completada: `toolsMCPAPI` tiene ahora las 5 tools de mant
 
 ### Bloqueos
 
-- **Tarea 3.3 (Almacenes en la fachada) espera que esta tarea (3.2) se mergee primero** — orden estricto de ADR-013. Es clase 🔴, con puntos de parada obligatoria ya anticipados en `sprint-3-prompts.md`.
+- **Tarea 3.3 (Almacenes en la fachada) DETENIDA — necesita respuesta de Rodolfo en 4 preguntas concretas antes de escribir código:**
+  1. **`crear_pedido_materiales`, ¿qué payload/flujo replica?** El PHP real (`Pedidosmateriales.php`) crea el pedido atado a una OT (`ortr_id`) y saca el detalle de `tbl_otinsumos` (`crearPedidoOT`) — no de un payload libre tipo "artículo + cantidad + depósito" como asumía ADR-012. ¿La tool MCP debe replicar ese flujo (recibe un `ot_id`, no una lista de artículos), o hace falta un flujo distinto para el piloto?
+  2. **¿El proceso Bonita se lanza por ID o por nombre?** `create_ot` usa `nombre_proceso` en el JSON hacia `/bpm/proceso/instancia`. El pedido de materiales usa `BPM_PROCESS_ID_PEDIDOS_NORMALES` = `8803232493891311406` (ID numérico) en el PHP. ¿El endpoint WSO2 de instanciación acepta ID además de nombre, o hay que resolver el nombre real de ese proceso en Bonita?
+  3. **El PHP no hace rollback (DELETE) del pedido si el BPM falla** — a diferencia de `create_ot`. ¿Se agrega el rollback igual (mejora sobre el comportamiento actual) o se replica el comportamiento real tal cual está hoy (sin rollback)?
+  4. **Lecturas: no hay query de "listado de pedidos de la empresa" en `ALMDataService`** (las que existen filtran por origen/tarea, no "todos los de mi empresa" como `mcp/ots`) — ¿hay que escribir una query nueva en el `.dbs` (toca un DataService compartido con el v2 en producción), o hay otra tabla/vista que sí sirva? Y la query de stock más completa (`getStock`) exige también `id_user` (encargado de depósito) además de `empr_id` — el JWT del agente no tiene ese dato hoy. ¿Usar una query sin ese filtro (ej. `getArticulos2`, solo por `empr_id`) alcanza para el piloto?
+  Detalle completo del relevamiento en la conversación con Claude Code del 2026-07-31.
 - Config de identidad (ADR-008/009) y migración de DataServices a PostgreSQL siguen pendientes antes de poder dar de alta al primer cliente sobre la VM de GCP — cubierto por E7-INFRA-03 (Bloque 2, no ejecutado todavía).
 - **Nota operativa (de E2-MCP-11, sigue vigente):** el deploy del `.car` de `ToolsAPIProject` es atómico — si `ALMDataService` (o cualquier otro `.dbs`) no puede conectar a su BD al momento del deploy, se revierte el CAR completo. Relevante para cuando se sumen las DataServices de almacenes (Tarea 3.3) y para el deploy en la VM de GCP.
 - La implementación de escritura MCP en Almacenes sigue bloqueada hasta que el PM confirme cómo resolver el aislamiento multi-tenant de `ALMDataService` (ver pregunta abierta #1 del relevamiento de Sprint 3) — posible tema de arquitectura (🔴).


### PR DESCRIPTION
## Qué cambia
No implementa nada de código. Documenta en `STATE.md` una parada obligatoria (clase 🔴, prevista explícitamente en `sprint-3-prompts.md`) al arrancar la Tarea 3.3 (sumar almacenes a `toolsMCPAPI`): el relevamiento del `ALMDataService` real y del PHP v2 que hoy crea pedidos de materiales encontró discrepancias con lo que asumía ADR-012.

## Por qué
El prompt de la Tarea 3.3 dice explícitamente: "si no conocés el proceso Bonita del pedido, el payload real, o si el ALMDataService no es análogo a MANDataService → PARÁ y consultá a Rodolfo. NO improvises un workaround." Encontré evidencia concreta de las 3 cosas — no adivino, no invento, pregunto.

## Cómo lo verifiqué
Relevamiento contra el código real del repo (no doc genérica):
- `_backend/api/ToolsAPIProject/.../artifacts/data-services/ALMDataService.dbs` (85 queries) — no hay una query de "listado de pedidos de la empresa" análoga a `mcp/ots`; la query de stock más completa (`getStock`) exige `id_user` además de `empr_id`.
- `application/modules/traz-comp-almacenes/models/new/Pedidosmateriales.php` — el flujo real de "crear pedido" está atado a una OT (`ortr_id`), con el detalle sacado de `tbl_otinsumos`, no de un payload libre de artículo+cantidad+depósito.
- `application/config/constants.php` — el proceso Bonita se identifica por ID numérico (`BPM_PROCESS_ID_PEDIDOS_NORMALES` = `8803232493891311406`), a diferencia de `create_ot` que usa `nombre_proceso`.
- El PHP no hace rollback (DELETE) explícito si el BPM falla, a diferencia del patrón ya probado de `create_ot`.

Las 4 preguntas concretas para desbloquear quedan en `STATE.md` (sección Bloqueos). No se tocó ningún artefacto de `toolsMCPAPI` ni ningún otro código — `git status` limpio antes de este commit.

No mergear — esto documenta un bloqueo, no cierra la tarea.