### PR TITLE
docs(infra): agregar doc de Ambientes DEV/TEST/PROD

### DIFF
--- a/doc/infra/ambientes.md
+++ b/doc/infra/ambientes.md
@@ -1,0 +1,120 @@
+# Ambientes de Trazalog v3 — DEV / TEST / PROD
+
+## Objetivo
+
+Este documento explica los ambientes donde corre el stack WSO2 (APIM + MI) de Trazalog v3, cómo levantar DEV en una máquina local (Rodolfo u otro developer), y cómo se usa TEST hoy (futuro PROD). Está escrito para cualquier developer que necesite decidir "¿dónde pruebo esto?" o "¿necesito ngrok para esto?".
+
+**Qué NO cubre:** la instalación paso a paso de WSO2 (eso está en [`wso2-install.md`](wso2-install.md) para DEV y [`doc/v3/deployment-gcp.md`](../v3/deployment-gcp.md) para TEST/PROD), el flujo de testing de tools MCP en sí ([`testing-workflow.md`](testing-workflow.md)), ni la arquitectura de identidad/federación con Dnato ([`doc/identity/oauth-discovery-flow.md`](../identity/oauth-discovery-flow.md), ADR-008/ADR-009). Este doc es el mapa que conecta esos documentos, no un reemplazo.
+
+---
+
+## 1. Resumen de los 3 ambientes
+
+| Ambiente | Dónde corre | Acceso público | Quién lo usa | Estado hoy (2026-08-08) |
+|---|---|---|---|---|
+| **DEV** | Máquina local de cada developer (WSO2 APIM+MI nativos) | Ninguno por defecto. Con ngrok, temporal y bajo demanda | Cada developer, individualmente | Activo — es el que se usa día a día |
+| **TEST** | VM GCP `e2-medium`, Rocky Linux 9, `us-east1-b` (ADR-011) | `https://mcp.cloudtrazalog.com` (Caddy + TLS Let's Encrypt). Consolas admin NUNCA públicas | Equipo completo, early adopter piloto (sector minero San Juan) | VM instalada y funcionando end-to-end (E7-INFRA-01/02). Todavía sin los artefactos de la fachada MCP desplegados (Tarea 3.5, pendiente) |
+| **PROD** | Futuro clon de TEST (misma receta, otra VM/dominio) | Igual esquema que TEST | Clientes reales | No existe todavía |
+
+---
+
+## 2. DEV — máquina local
+
+### 2.1 Cuándo alcanza con `localhost` (sin ngrok)
+
+Para el trabajo del día a día — escribir y probar Synapse APIs, DataServices, correr los tests Hurl, usar Publisher/DevPortal/Carbon — **nunca hace falta ngrok**. Se accede directo:
+
+```
+https://localhost:9443/publisher
+https://localhost:9443/devportal
+https://localhost:9443/carbon
+```
+
+Instalación completa en [`wso2-install.md`](wso2-install.md).
+
+### 2.2 Cuándo hace falta ngrok
+
+Solo cuando algo **externo a tu máquina** necesita alcanzar tu instancia local:
+
+- **(a) Probar el conector MCP desde Claude.ai** — Claude.ai necesita una URL pública para invocar el servidor MCP. Ver [`ngrok-setup.md`](ngrok-setup.md) y [`testing-workflow.md`](testing-workflow.md) Etapa 2.
+- **(b) Probar el flujo completo de federación de identidad con Dnato** (ADR-008/009) — cuando Dnato también necesita ser alcanzable públicamente para que el intercambio OAuth (authorization code, JWKS, PRM) funcione de punta a punta. `scripts/dev/setup-ngrok.sh` automatiza este caso: levanta 2 túneles (APIM gateway 8243 + Dnato 80), actualiza `deployment.toml`, reinicia APIM, y actualiza el issuer del Resident Key Manager.
+
+### 2.3 Cómo levantar una sesión de DEV con ngrok
+
+1. Instalar y autenticar ngrok (una sola vez) — [`ngrok-setup.md`](ngrok-setup.md) §1-2.
+2. Levantar WSO2 APIM + MI local ([`wso2-install.md`](wso2-install.md)).
+3. Levantar los 2 túneles ngrok (config file o 2 terminales — ver cabecera de `scripts/dev/setup-ngrok.sh` para el detalle exacto).
+4. Correr:
+   ```bash
+   export APIM_HOME=/ruta/a/tu/wso2am-4.6.0
+   bash scripts/dev/setup-ngrok.sh
+   ```
+   Esto detecta las URLs públicas de los túneles, actualiza `hostname`/`https_endpoint`/`issuer` en `deployment.toml` (con backup automático `.bak.<timestamp>`), reinicia APIM, actualiza el Resident Key Manager, e imprime la URL del conector MCP para Claude.ai y las variables de entorno para Dnato.
+5. Trabajar / probar.
+6. **Paso obligatorio al terminar la sesión:**
+   ```bash
+   bash scripts/dev/setup-ngrok.sh --reset
+   ```
+   Esto revierte `hostname`/`issuer`/`https_endpoint` a `localhost` y reinicia APIM.
+
+> **Por qué este paso es obligatorio y no opcional:** si te salteás el `--reset`, la próxima vez que quieras entrar a Publisher/DevPortal sin ngrok corriendo, APIM va a intentar redirigirte al login vía la URL vieja de ngrok — que ya no existe — y vas a quedar sin poder loguearte, aunque tu instancia esté sana. Esto pasó en la práctica el 2026-08-08: `setup-ngrok.sh` se había corrido (al menos) dos veces desde el 2026-06-30 sin `--reset` después, dejando `hostname` pisado con un subdominio ngrok muerto durante más de un mes. Se corrigió corriendo `--reset` manualmente y reiniciando APIM — ver `doc/v3/STATE.md`.
+
+### 2.4 La URL de ngrok cambia en cada sesión — ¿está considerado?
+
+Sí, en dos frentes distintos:
+
+- **Conector MCP en Claude.ai**: hay que reconfigurar manualmente (Settings → Connectors → editar URL) cada vez que ngrok se reinicia — el plan free no tiene dominios fijos. Documentado en [`ngrok-setup.md`](ngrok-setup.md) §4.
+- **`deployment.toml`**: `setup-ngrok.sh` no asume una URL fija — en cada corrida vuelve a leer la URL activa desde la API local de ngrok (`http://localhost:4040/api/tunnels`). Lo único que **no** se resuelve solo es el `--reset` al final de la sesión (§2.3 paso 6) — depende de que el developer lo corra.
+
+### 2.5 Multi-developer
+
+Cada developer levanta su propia instancia local (APIM + MI + ngrok) de forma completamente independiente, siguiendo [`wso2-install.md`](wso2-install.md) desde cero en su máquina. No hay nada compartido entre developers en DEV — las URLs de ngrok de uno no interfieren con las de otro, cada uno usa su propia cuenta ngrok free.
+
+---
+
+## 3. TEST (hoy) / PROD (futuro) — VM GCP
+
+### 3.1 Qué es TEST hoy
+
+VM `e2-medium`, zona `us-east1-b`, Rocky Linux 9, con WSO2 APIM 4.6.0 + MI 4.5.0 instalados **nativamente** (sin contenedores, sin ngrok, sin túneles) — ADR-011, detalle completo en [`doc/v3/deployment-gcp.md`](../v3/deployment-gcp.md).
+
+- Dominio público: `mcp.cloudtrazalog.com`, TLS automático vía Caddy (Let's Encrypt).
+- Puerto 9443 (carbon/publisher/devportal) **nunca se expone públicamente** — solo alcanzable por túnel SSH o red interna del proyecto GCP (`deployment-gcp.md` §3 y §4 paso 9).
+
+**Estado actual:** la VM está instalada y funcionando end-to-end (E7-INFRA-01/02, PR #403/#404), pero todavía no tiene desplegados los artefactos de la fachada MCP unificada (`toolsMCPAPI`, `toolsALMAPI`, etc.) — eso es la Tarea 3.5 (E7-INFRA-05), pendiente de confirmación de Rodolfo sobre si la verificación en DEV de E2-MCP-13 alcanza como prerequisito (ver `doc/v3/STATE.md`).
+
+### 3.2 Cómo acceder a TEST
+
+- **Gateway público** (invocación de APIs/MCP): `https://mcp.cloudtrazalog.com` — directo, sin VPN ni túnel.
+- **Consolas admin** (carbon/publisher/devportal): solo vía túnel SSH:
+  ```bash
+  gcloud compute ssh NOMBRE_VM --zone=us-east1-b --tunnel-through-iap -- -L 9443:localhost:9443
+  ```
+  y después `https://localhost:9443/publisher` en tu navegador (certificado self-signed, la advertencia del navegador es esperada).
+
+**No hace falta ngrok en TEST** — a diferencia de DEV, ya tiene un dominio público estable con TLS real vía Caddy.
+
+### 3.3 Cómo desplegar cambios a TEST
+
+No existe todavía un script equivalente a `scripts/dev/rebuild-and-deploy-mi.sh` (el de DEV) para TEST — hoy el despliegue a la VM GCP es manual, siguiendo `deployment-gcp.md` §4 pasos 6-8. No se armó un script dedicado porque la Tarea 3.5 (primer despliegue real de la fachada MCP a esta VM) todavía no se ejecutó. Si el despliegue a TEST se vuelve frecuente una vez arrancada esa tarea, vale la pena automatizarlo — queda marcado acá para cuando corresponda.
+
+### 3.4 PROD (futuro)
+
+Todavía no existe. El plan (parte de ADR-011, no ejecutado) es clonar la receta de TEST — misma VM (nueva instancia, sizing igual o ajustado según el uso real del piloto), mismo Caddy+TLS, pero con su propio dominio/IP. Antes de dar de alta al primer cliente real sobre esa VM, quedan dos pendientes que hoy están fuera de alcance de TEST:
+
+- Config de identidad completa (ADR-008/ADR-009) contra el Dnato de ese ambiente.
+- Migración de DataServices a PostgreSQL (hoy MySQL/PostgreSQL mezclados — ver `doc/identity/dataservices-remediation-phase-a.md`, en curso, no cerrada).
+
+No hay fecha ni VM creada todavía — se define cuando el piloto con el early adopter minero valide el approach en TEST.
+
+---
+
+## 4. Resumen rápido — ¿qué uso cuándo?
+
+| Necesito... | Uso |
+|---|---|
+| Desarrollar o debuggear una API/DataService | DEV local, sin ngrok |
+| Probar una tool MCP con Claude.ai | DEV local + ngrok ([`testing-workflow.md`](testing-workflow.md) Etapa 2), o TEST directamente si ya está desplegado ahí |
+| Probar el login/flujo completo con Dnato | DEV local + `setup-ngrok.sh` (2 túneles), o TEST (dominio real, sin ngrok) |
+| Mostrarle algo a alguien fuera del equipo, o probar con el early adopter | TEST |
+| Dar de alta un cliente real en producción | Todavía no existe — esperar a que TEST valide y clonar (§3.4) |

--- a/doc/v3/STATE.md
+++ b/doc/v3/STATE.md
@@ -14,12 +14,14 @@
 
 **Sprint actual:** Sprint 3 — Activación early adopter minero
 **Objetivo del sprint:** Reemplazar ngrok por un despliegue estable en GCP (ADR-011) y cerrar la deuda técnica pendiente antes de activar al primer cliente early adopter.
-**Última actualización:** 2026-08-03 por Claude Code (E2-MCP-13 / tarea 3.4)
+**Última actualización:** 2026-08-08 por Claude Code (doc de Ambientes + fix hostname ngrok en DEV)
 
 ### Tareas activas
 
 | ID | Descripción | Clase | Estado | Rama / PR |
 |---|---|---|---|---|
+| — | Doc de Ambientes (DEV/TEST/PROD) + fix de `hostname` pisado con ngrok en APIM local de Rodolfo | 🟢 | **Completada.** `doc/infra/ambientes.md` nuevo — cuándo hace falta ngrok en DEV, cómo usar TEST hoy, plan de PROD. En el camino: `deployment.toml` local de Rodolfo tenía `hostname` pisado con un subdominio ngrok muerto (`scripts/dev/setup-ngrok.sh` corrido al menos 2 veces desde 2026-06-30 sin `--reset` después, confirmado por los `.bak.*` del archivo), rompiendo el login a Publisher/DevPortal. Corregido con `setup-ngrok.sh --reset` + reinicio de APIM (verificado: redirect ya no va a ngrok) | `docs/ambientes-dev-test-prod` — PR abierto, sin mergear |
+| — | Prueba de humo de E2-MCP-13 en DEV (VPN+DB reales) + fix bug `case_id` null en `man_get_ot`/`man_get_ots` | 🟡 | **Completada.** 9/9 tools probadas con datos reales (empr_id=1): 7 reads OK, 2 writes OK end-to-end con Bonita real (`man_create_ot` → OT 291/case 30001, `alm_crear_pedido_materiales` → pedido 1481/case 30002, ambos marcados como descartables para limpieza). Bug preexistente encontrado y arreglado: `getOTsByEmpresa`/`getSolicitudServicioById` en `MANDataService.dbs` leían `case_id` del LEFT JOIN a `orden_trabajo` en vez de la tabla base `solicitud_reparacion` — daba `null` en OTs recién creadas (verificado preexistente contra el endpoint original de `toolsMANAPI`, no introducido por la unificación). Fix verificado en vivo contra DEV real (MI local rebuild+redeploy) | `fix/e2-mcp-case-id-null-man-queries` — PR abierto, sin mergear |
 | E2-MCP-13 (3.4) | OpenAPI unificada + Virtual MCP Server único + guía de migración (Bloque 3, tarea 3.4) | 🟡 | **Completada.** `doc/api/trazalog-operaciones.yaml` (9 tools, `empr_id` ausente, validada con `openapi-spec-validator`) + `doc/mcp/virtual-mcp-unificado.md` (pasos de consola + migración coordinada + smoke test) | `feature/e2-mcp-13-openapi-unificada` — PR abierto, sin mergear |
 | E1-ALM (3.3) | Sumar almacenes a la fachada (Bloque 3, tarea 3.3) | 🔴 | Completada y mergeada | PR #413 |
 | E2-MCP-12 | Migrar las 5 tools de mantenimiento a `toolsMCPAPI` (Bloque 3, tarea 3.2) | 🟡 | Completada y mergeada | PR #411 |
@@ -38,6 +40,7 @@ Tarea 3.4 completada: `trazalog-operaciones.yaml` reúne las 9 tools (5 mantenim
 
 | Fecha | Decisión | Referencia |
 |---|---|---|
+| 2026-08-08 | **Doc de Ambientes creado**, a pedido de Rodolfo, tras confundirse con un redirect a ngrok al entrar a Publisher. Documenta cuándo DEV necesita ngrok (testing MCP con Claude.ai, federación Dnato) y cuándo no (trabajo diario), más el estado y acceso de TEST/PROD. Se identificó y corrigió la causa raíz del problema puntual: `hostname` en el `deployment.toml` local quedó pisado con un subdominio ngrok muerto por no haber corrido `--reset` al cerrar sesiones anteriores | `doc/infra/ambientes.md`, `scripts/dev/setup-ngrok.sh` |
 | 2026-08-03 | **Tarea 3.4 completada.** OpenAPI unificada de las 9 tools + doc de Virtual MCP Server único con guía de migración coordinada. Detectada y corregida staleness en `openapi-publish-procedure.md` (describe `X-Empr-Id` en vez del `X-JWT-Assertion` vigente de ADR-009) — no corregida en el doc viejo, solo evitada en el nuevo | `doc/api/trazalog-operaciones.yaml`, `doc/mcp/virtual-mcp-unificado.md` |
 | 2026-08-02 | Rodolfo confirmó el nombre real del proceso Bonita para `alm_crear_pedido_materiales`: **"Pedido de Recursos Materiales"** — la etiqueta `"Ped. Materiales"` de `constants.php` (usada como suposición inicial) NO era el nombre real registrado en Bonita. Corregido en `toolsALMAPI.xml` y en el test Hurl | `toolsALMAPI.xml`, `tests/security/mcp-facade-alm-tools.hurl` |
 | 2026-07-31 | **Tarea 3.3 (almacenes) completada y mergeada.** `toolsALMAPI.xml` (nuevo, contexto `/tools/alm`) como capa de orquestación que recibe `empr_id` EXPLÍCITO (no derivado de JWT) — decisión de Rodolfo, reusable a futuro por el PHP de v2. `toolsMCPAPI` expone 4 tools `alm_*` como fachada delgada. 3 queries aditivas en `ALMDataService.dbs`. Rollback de 3 niveles | PR #413, `toolsALMAPI.xml`, `toolsMCPAPI.xml`, `ALMDataService.dbs` |


### PR DESCRIPTION
## Qué cambia
Nuevo `doc/infra/ambientes.md`: explica cuándo DEV necesita ngrok (testing MCP con Claude.ai, federación Dnato) y cuándo no (trabajo diario con localhost), el paso `--reset` obligatorio al cerrar una sesión con ngrok, y cómo acceder/usar TEST hoy (VM GCP, ADR-011) más el plan de PROD a futuro.

## Por qué
Rodolfo se topó con un redirect a una URL de ngrok muerta al intentar entrar a `https://localhost:9443/publisher/` y preguntó si ngrok es un requisito permanente de DEV (no lo es) y si la URL cambiante de ngrok está contemplada (sí, pero solo parcialmente). No había ningún documento que explicara la relación entre los 3 ambientes ni cuándo cada uno necesita o no ngrok.

Causa raíz del problema puntual: el `deployment.toml` local de Rodolfo tenía `hostname` pisado con un subdominio ngrok que ya no existe. Los backups (`deployment.toml.bak.*`) muestran que `scripts/dev/setup-ngrok.sh` se corrió al menos 2 veces desde 2026-06-30 sin ejecutar `--reset` después de cada sesión — quedó así por más de un mes.

## Cómo lo verifiqué
- Corrí `scripts/dev/setup-ngrok.sh --reset` contra el APIM local: revirtió `hostname`/`https_endpoint`/`issuer` a `localhost` en `deployment.toml` (confirmado con `grep`).
- Reinicié APIM (el `stop` del script no mata el proceso realmente — mismo bug que ya se había visto con MI; lo maté a mano y reinicié) — log confirma `WSO2 Carbon started in 133 sec`, sin errores.
- Probé el endpoint de authorize con un `client_id` dummy: el redirect ahora apunta a `https://localhost:9443/...` (antes iba a `https://<ngrok>.ngrok-free.app:9443/...`).
- Doc revisado contra el estado real de `deployment-gcp.md` (TEST) y `ngrok-setup.md`/`setup-ngrok.sh` (DEV) para no introducir inconsistencias.

Closes N/A — doc + fix operativo motivados por una consulta directa de Rodolfo, sin issue propio todavía.