### PR TITLE
fix(alm): segundo resource /articulos/{empr_id} del EI → getArticulos2, como el MI [F1]

### DIFF
--- a/_backend/api/dataservice/ALMDataService.dbs
+++ b/_backend/api/dataservice/ALMDataService.dbs
@@ -633,7 +633,7 @@
       </call-query>
    </resource>
    <resource method="GET" path="/articulos/{empr_id}">
-      <call-query href="getArticulos">
+      <call-query href="getArticulos2">
          <with-param name="empr_id" query-param="empr_id"/>
       </call-query>
    </resource>


### PR DESCRIPTION
## Qué cambia

Una línea funcional: el segundo resource `GET /articulos/{empr_id}` de la copia EI de `ALMDataService.dbs` pasa de `getArticulos` a `getArticulos2` (+ su `with-param`), igualando la copia MI.

## Por qué

Error mío en la sincronización de F1 (#426): al portar el resource desde el MI copié el primer bloque con ese path en vez del segundo. Lo detectó el smoke de F3 contra DEV. **Sin impacto funcional servido** — con el path duplicado responde siempre el primero (`getArticulos`) en ambas copias, y por eso mismo el helper de asset (F3) quedó apuntando al path sin ambigüedad `/articulos/empresa/{empr_id}` — pero rompía la igualdad EI=MI que exige D9.

Deuda preexistente que este PR no toca (viene así del MI): el path `/articulos/{empr_id}` está duplicado por diseño heredado; el segundo resource es inalcanzable en la práctica. Candidato a limpiarse en ambas copias cuando se retome la unificación.

## Cómo lo verifiqué

- Ambas copias quedan `[getArticulos, getArticulos2]` para ese path (comparación automática post-edición).
- XML well-formed.
- El seguimiento de fase vive en `traz-prod-assetplanner/doc/v3/STATE.md` (fila F3, corrección registrada ahí).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015x4EqTGKc2PV4we7mX3w8s