### PR TITLE
fix(alm): resources de /pedidos/orden antes que los genéricos [F5]

### DIFF
--- a/_backend/api/ToolsAPIProject/ToolsAPIProject/src/main/wso2mi/artifacts/data-services/ALMDataService.dbs
+++ b/_backend/api/ToolsAPIProject/ToolsAPIProject/src/main/wso2mi/artifacts/data-services/ALMDataService.dbs
@@ -613,6 +613,32 @@
          <with-param name="empr_id" query-param="empr_id"/>
       </call-query>
    </resource>
+   <resource method="GET" path="/pedidos/orden/{ortr_id}/{empr_id}">
+      <call-query href="getPedidoPorOrden">
+         <with-param name="ortr_id" query-param="ortr_id"/>
+         <with-param name="empr_id" query-param="empr_id"/>
+      </call-query>
+   </resource>
+   <resource method="POST" path="/pedidos/orden">
+      <call-query href="setPedidoOrden">
+         <with-param name="ortr_id" query-param="ortr_id"/>
+         <with-param name="estado" query-param="estado"/>
+         <with-param name="empr_id" query-param="empr_id"/>
+      </call-query>
+   </resource>
+   <resource method="PUT" path="/pedidos/estado">
+      <call-query href="setEstadoPedido">
+         <with-param name="estado" query-param="estado"/>
+         <with-param name="pema_id" query-param="pema_id"/>
+      </call-query>
+   </resource>
+   <resource method="POST" path="/pedidos/detalle/orden">
+      <call-query href="setDetallePedidoOrden">
+         <with-param name="cantidad" query-param="cantidad"/>
+         <with-param name="pema_id" query-param="pema_id"/>
+         <with-param name="arti_id" query-param="arti_id"/>
+      </call-query>
+   </resource>
    <resource method="POST" path="/pedidos">
       <call-query href="setPedido">
          <with-param name="fecha" query-param="fecha"/>
@@ -657,32 +683,6 @@
    <resource method="DELETE" path="/pedidos">
       <call-query href="deletePedido">
          <with-param name="pema_id" query-param="pema_id"/>
-      </call-query>
-   </resource>
-   <resource method="GET" path="/pedidos/orden/{ortr_id}/{empr_id}">
-      <call-query href="getPedidoPorOrden">
-         <with-param name="ortr_id" query-param="ortr_id"/>
-         <with-param name="empr_id" query-param="empr_id"/>
-      </call-query>
-   </resource>
-   <resource method="POST" path="/pedidos/orden">
-      <call-query href="setPedidoOrden">
-         <with-param name="ortr_id" query-param="ortr_id"/>
-         <with-param name="estado" query-param="estado"/>
-         <with-param name="empr_id" query-param="empr_id"/>
-      </call-query>
-   </resource>
-   <resource method="PUT" path="/pedidos/estado">
-      <call-query href="setEstadoPedido">
-         <with-param name="estado" query-param="estado"/>
-         <with-param name="pema_id" query-param="pema_id"/>
-      </call-query>
-   </resource>
-   <resource method="POST" path="/pedidos/detalle/orden">
-      <call-query href="setDetallePedidoOrden">
-         <with-param name="cantidad" query-param="cantidad"/>
-         <with-param name="pema_id" query-param="pema_id"/>
-         <with-param name="arti_id" query-param="arti_id"/>
       </call-query>
    </resource>
    <resource method="GET" path="/pedidos/batch/{batch_id}">

--- a/_backend/api/dataservice/ALMDataService.dbs
+++ b/_backend/api/dataservice/ALMDataService.dbs
@@ -598,6 +598,32 @@
          <with-param name="empr_id" query-param="empr_id"/>
       </call-query>
    </resource>
+   <resource method="GET" path="/pedidos/orden/{ortr_id}/{empr_id}">
+      <call-query href="getPedidoPorOrden">
+         <with-param name="ortr_id" query-param="ortr_id"/>
+         <with-param name="empr_id" query-param="empr_id"/>
+      </call-query>
+   </resource>
+   <resource method="POST" path="/pedidos/orden">
+      <call-query href="setPedidoOrden">
+         <with-param name="ortr_id" query-param="ortr_id"/>
+         <with-param name="estado" query-param="estado"/>
+         <with-param name="empr_id" query-param="empr_id"/>
+      </call-query>
+   </resource>
+   <resource method="PUT" path="/pedidos/estado">
+      <call-query href="setEstadoPedido">
+         <with-param name="estado" query-param="estado"/>
+         <with-param name="pema_id" query-param="pema_id"/>
+      </call-query>
+   </resource>
+   <resource method="POST" path="/pedidos/detalle/orden">
+      <call-query href="setDetallePedidoOrden">
+         <with-param name="cantidad" query-param="cantidad"/>
+         <with-param name="pema_id" query-param="pema_id"/>
+         <with-param name="arti_id" query-param="arti_id"/>
+      </call-query>
+   </resource>
    <resource method="POST" path="/pedidos">
       <call-query href="setPedido">
          <with-param name="fecha" query-param="fecha"/>
@@ -641,32 +667,6 @@
    <resource method="DELETE" path="/pedidos">
       <call-query href="deletePedido">
          <with-param name="pema_id" query-param="pema_id"/>
-      </call-query>
-   </resource>
-   <resource method="GET" path="/pedidos/orden/{ortr_id}/{empr_id}">
-      <call-query href="getPedidoPorOrden">
-         <with-param name="ortr_id" query-param="ortr_id"/>
-         <with-param name="empr_id" query-param="empr_id"/>
-      </call-query>
-   </resource>
-   <resource method="POST" path="/pedidos/orden">
-      <call-query href="setPedidoOrden">
-         <with-param name="ortr_id" query-param="ortr_id"/>
-         <with-param name="estado" query-param="estado"/>
-         <with-param name="empr_id" query-param="empr_id"/>
-      </call-query>
-   </resource>
-   <resource method="PUT" path="/pedidos/estado">
-      <call-query href="setEstadoPedido">
-         <with-param name="estado" query-param="estado"/>
-         <with-param name="pema_id" query-param="pema_id"/>
-      </call-query>
-   </resource>
-   <resource method="POST" path="/pedidos/detalle/orden">
-      <call-query href="setDetallePedidoOrden">
-         <with-param name="cantidad" query-param="cantidad"/>
-         <with-param name="pema_id" query-param="pema_id"/>
-         <with-param name="arti_id" query-param="arti_id"/>
       </call-query>
    </resource>
    <resource method="GET" path="/pedidos/batch/{batch_id}">


### PR DESCRIPTION
## Qué cambia

Mueve los 4 resources de #428 al tope del bloque de pedidos en ambas copias de `ALMDataService`. Sin cambios de queries.

## Por qué

El matching de URI templates del DSS es goloso: `GET /pedidos/{pema_id}/{empr_id}` capturaba `/pedidos/orden/{ot}/{empr}` metiendo `orden` como `pema_id`. Verificado contra DEV con el fault real: `current_params {pema_id=orden, empr_id=999999/1}`. Más-específico-primero — el mismo landmine de orden que ya apareció con `/articulos/{empr_id}`.

## Cómo lo verifiqué

XML válido en ambas copias y orden verificado programáticamente (`/pedidos/orden` antes que `/pedidos/{pema_id}`). El smoke real necesita **redeploy del `ALMDataService.dbs` en el EI de DEV** después del merge — junto con el `PANDataservice.dbs` que sigue sin redesplegar (404 en `/herramientas/empresa/{empr_id}`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015x4EqTGKc2PV4we7mX3w8s