### PR TITLE
fix(alm): setDetallePedidoOrden no puede repetir :cantidad [F5]

### DIFF
--- a/_backend/api/ToolsAPIProject/ToolsAPIProject/src/main/wso2mi/artifacts/data-services/ALMDataService.dbs
+++ b/_backend/api/ToolsAPIProject/ToolsAPIProject/src/main/wso2mi/artifacts/data-services/ALMDataService.dbs
@@ -603,7 +603,7 @@
       <param name="pema_id" sqlType="STRING"/>
    </query>
    <query id="setDetallePedidoOrden" useConfig="ToolsDataSource">
-      <sql>INSERT INTO alm.alm_deta_pedidos_materiales (cantidad, pema_id, arti_id, resto) VALUES(cast(:cantidad as float4), cast(:pema_id as integer), cast(:arti_id as integer), cast(:cantidad as float4));</sql>
+      <sql>INSERT INTO alm.alm_deta_pedidos_materiales (cantidad, pema_id, arti_id, resto) SELECT p.c, p.p, p.a, p.c FROM (SELECT cast(:cantidad as float4) c, cast(:pema_id as integer) p, cast(:arti_id as integer) a) p;</sql>
       <param name="cantidad" sqlType="STRING"/>
       <param name="pema_id" sqlType="STRING"/>
       <param name="arti_id" sqlType="STRING"/>

--- a/_backend/api/dataservice/ALMDataService.dbs
+++ b/_backend/api/dataservice/ALMDataService.dbs
@@ -588,7 +588,7 @@
       <param name="pema_id" sqlType="STRING"/>
    </query>
    <query id="setDetallePedidoOrden" useConfig="ToolsDataSource">
-      <sql>INSERT INTO alm.alm_deta_pedidos_materiales (cantidad, pema_id, arti_id, resto) VALUES(cast(:cantidad as float4), cast(:pema_id as integer), cast(:arti_id as integer), cast(:cantidad as float4));</sql>
+      <sql>INSERT INTO alm.alm_deta_pedidos_materiales (cantidad, pema_id, arti_id, resto) SELECT p.c, p.p, p.a, p.c FROM (SELECT cast(:cantidad as float4) c, cast(:pema_id as integer) p, cast(:arti_id as integer) a) p;</sql>
       <param name="cantidad" sqlType="STRING"/>
       <param name="pema_id" sqlType="STRING"/>
       <param name="arti_id" sqlType="STRING"/>


### PR DESCRIPTION
El DSS tira NPE si un parámetro nombrado aparece dos veces en el SQL (fault verificado en DEV al insertar detalle). Reescrita con tabla derivada (patrón `setTabla`), `resto = cantidad` por alias. SQL validado contra Postgres DEV con BEGIN/ROLLBACK. Ambas copias. **Requiere redeploy del `ALMDataService.dbs` tras el merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015x4EqTGKc2PV4we7mX3w8s