### PR TITLE
revert(alm): quitar setDetallePedidoOrden — el trigger ya completa resto [F5]

### DIFF
--- a/_backend/api/ToolsAPIProject/ToolsAPIProject/src/main/wso2mi/artifacts/data-services/ALMDataService.dbs
+++ b/_backend/api/ToolsAPIProject/ToolsAPIProject/src/main/wso2mi/artifacts/data-services/ALMDataService.dbs
@@ -602,12 +602,6 @@
       <param name="estado" sqlType="STRING"/>
       <param name="pema_id" sqlType="STRING"/>
    </query>
-   <query id="setDetallePedidoOrden" useConfig="ToolsDataSource">
-      <sql>INSERT INTO alm.alm_deta_pedidos_materiales (cantidad, pema_id, arti_id, resto) SELECT p.c, p.p, p.a, p.c FROM (SELECT cast(:cantidad as float4) c, cast(:pema_id as integer) p, cast(:arti_id as integer) a) p;</sql>
-      <param name="cantidad" sqlType="STRING"/>
-      <param name="pema_id" sqlType="STRING"/>
-      <param name="arti_id" sqlType="STRING"/>
-   </query>
    <resource method="GET" path="/articulos/{empr_id}">
       <call-query href="getArticulos">
          <with-param name="empr_id" query-param="empr_id"/>
@@ -630,13 +624,6 @@
       <call-query href="setEstadoPedido">
          <with-param name="estado" query-param="estado"/>
          <with-param name="pema_id" query-param="pema_id"/>
-      </call-query>
-   </resource>
-   <resource method="POST" path="/pedidos/detalle/orden">
-      <call-query href="setDetallePedidoOrden">
-         <with-param name="cantidad" query-param="cantidad"/>
-         <with-param name="pema_id" query-param="pema_id"/>
-         <with-param name="arti_id" query-param="arti_id"/>
       </call-query>
    </resource>
    <resource method="POST" path="/pedidos">

--- a/_backend/api/dataservice/ALMDataService.dbs
+++ b/_backend/api/dataservice/ALMDataService.dbs
@@ -587,12 +587,6 @@
       <param name="estado" sqlType="STRING"/>
       <param name="pema_id" sqlType="STRING"/>
    </query>
-   <query id="setDetallePedidoOrden" useConfig="ToolsDataSource">
-      <sql>INSERT INTO alm.alm_deta_pedidos_materiales (cantidad, pema_id, arti_id, resto) SELECT p.c, p.p, p.a, p.c FROM (SELECT cast(:cantidad as float4) c, cast(:pema_id as integer) p, cast(:arti_id as integer) a) p;</sql>
-      <param name="cantidad" sqlType="STRING"/>
-      <param name="pema_id" sqlType="STRING"/>
-      <param name="arti_id" sqlType="STRING"/>
-   </query>
    <resource method="GET" path="/articulos/{empr_id}">
       <call-query href="getArticulos">
          <with-param name="empr_id" query-param="empr_id"/>
@@ -615,13 +609,6 @@
       <call-query href="setEstadoPedido">
          <with-param name="estado" query-param="estado"/>
          <with-param name="pema_id" query-param="pema_id"/>
-      </call-query>
-   </resource>
-   <resource method="POST" path="/pedidos/detalle/orden">
-      <call-query href="setDetallePedidoOrden">
-         <with-param name="cantidad" query-param="cantidad"/>
-         <with-param name="pema_id" query-param="pema_id"/>
-         <with-param name="arti_id" query-param="arti_id"/>
       </call-query>
    </resource>
    <resource method="POST" path="/pedidos">


### PR DESCRIPTION
## Qué cambia

Quita `setDetallePedidoOrden` y su resource `POST /pedidos/detalle/orden` de ambas copias. **Las otras tres queries de #428 quedan** (`getPedidoPorOrden`, `setPedidoOrden`, `setEstadoPedido`) — las tres verificadas en el smoke end-to-end de F5.

## Por qué

`alm.alm_deta_pedidos_materiales` tiene el trigger **`tgrupdateresto` (AFTER INSERT)** que completa `resto = cantidad`. La agregué para setear `resto` a mano, sobre una suposición que no verifiqué contra el esquema; el `POST /pedidos/detalle` preexistente ya hacía el trabajo. Además era la query que tiraba el NPE del DSS.

El consumidor ya apunta al endpoint existente (asset #330), así que esto es limpieza: **no bloquea nada ni requiere redeploy urgente**.

## Cómo lo verifiqué

XML válido en ambas copias y ausencia de la query/resource verificada programáticamente. El flujo completo quedó probado contra DEV sin esta query (pedido 1486, detalle con `resto=13` puesto por el trigger, Bonita case 30010).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015x4EqTGKc2PV4we7mX3w8s