### PR TITLE
fix(dataservice): quitar /articulos/{empr_id} duplicado que rompe el deploy en EI [REQ-ASSET-ALM]

### DIFF
--- a/_backend/api/ToolsAPIProject/ToolsAPIProject/src/main/wso2mi/artifacts/data-services/ALMDataService.dbs
+++ b/_backend/api/ToolsAPIProject/ToolsAPIProject/src/main/wso2mi/artifacts/data-services/ALMDataService.dbs
@@ -714,11 +714,6 @@
          <with-param name="esta_id" query-param="esta_id"/>
       </call-query>
    </resource>
-   <resource method="GET" path="/articulos/{empr_id}">
-      <call-query href="getArticulos2">
-         <with-param name="empr_id" query-param="empr_id"/>
-      </call-query>
-   </resource>
    <!-- MCP: depósitos de la empresa (tool alm_get_depositos) -->
    <resource method="GET" path="/mcp/depositos/{empr_id}">
       <call-query href="getDepositosMcp">

--- a/_backend/api/dataservice/ALMDataService.dbs
+++ b/_backend/api/dataservice/ALMDataService.dbs
@@ -669,11 +669,6 @@
          <with-param name="esta_id" query-param="esta_id"/>
       </call-query>
    </resource>
-   <resource method="GET" path="/articulos/{empr_id}">
-      <call-query href="getArticulos2">
-         <with-param name="empr_id" query-param="empr_id"/>
-      </call-query>
-   </resource>
    <resource method="GET" path="/mcp/depositos/{empr_id}">
       <call-query href="getDepositosMcp">
          <with-param name="empr_id" query-param="empr_id"/>


### PR DESCRIPTION
## Qué cambia

Elimina el resource `GET /articulos/{empr_id}` **duplicado** en `ALMDataService.dbs` (copias EI y MI). Había quedado declarado dos veces: una apuntando a `getArticulos` y otra a `getArticulos2`.

## Por qué

Al desplegar en el WSO2 **EI 6.5** de producción, un `.dbs` con dos `<resource>` de igual `method`+`path` es inválido: el DSS rechaza el servicio entero y **se cae todo `ALMDataService`**, con él el módulo ALM de v2 en producción. El duplicado se introdujo en F1 (PR #426/#427) al sincronizar la copia EI con la MI — la MI (WSO2 más nuevo) lo toleraba, el EI 6.5 no. Por eso el MCP seguía verde y v2 se rompió.

**Alcance del daño (verificado):**
- Único archivo con contrato roto: `ALMDataService` (ambas copias, mismo duplicado). `COREDataService` fue puramente aditivo.
- **MCP no afectado:** usa `/mcp/stock`, `/mcp/depositos`, `/mcp/vencimientos`, `/pedidos/*` — nunca `/articulos/{empr_id}`.
- **Aislamiento por empresa preservado:** vive en `getArticulos` (`WHERE A.empr_id = :empr_id` + join `C.empr_id = A.empr_id`), que es la query que consumen v2 (`/articulos/{empr_id}`) y asset (`/articulos/empresa/{empr_id}`). `getArticulos2` no lo referenciaba ningún otro resource — la query queda definida pero sin exponer.

Se corrige en **ambas copias** (D9: EI y MI funcionalmente iguales) para sacar la mina latente del MI.

## Cómo lo verifiqué

- `python3 xml.dom.minidom.parse` → XML well-formed en las dos copias.
- `grep 'path="/articulos/{empr_id}"'` → **1** ocurrencia por archivo (antes 2).
- Confirmado que ningún caller de v2 usa `/articulos` bare ni `/articulos/obtener/{arti_id}`, y que asset consume `/articulos/empresa/{empr_id}`.
- **Pendiente de smoke en DEV** tras redeploy del `.car` (no incluido en este PR).

⚠️ **No mergear/desplegar sin tu OK** — este PR restaura producción; el redeploy del `.dbs`/`.car` en el EI es manual.